### PR TITLE
[mlir][wasm] Introduce reference type for local variables and function arguments

### DIFF
--- a/mlir/include/mlir/Dialect/WebAssembly/IR/WebAssemblyOps.td
+++ b/mlir/include/mlir/Dialect/WebAssembly/IR/WebAssemblyOps.td
@@ -78,18 +78,18 @@ def Wasm_FuncOp : Wasm_Op<"func", [
     IsolatedFromAbove,
     Symbol]> {
   let description = [{
-    Represents a wasm function definition.
+    Represents a Wasm function definition.
 
     In Wasm function, locals and function arguments are interchangeable.
     They are for instance both accessed using `local.get` instruction.
 
-    In the other hand, function type is defined as a a pair of tuples of Wasm value types.
+    On the other hand, a function type is defined as a pair of tuples of Wasm value types.
     To model this, the wasm.func operation has:
 
     - A function type that represents the corresponding wasm type (tuples of value types)
 
     - Arguments of the entry block of type `!wasm<local T>`, with T the corresponding type
-     in thr function type.
+     in the function type.
   }];
   let arguments = (ins SymbolNameAttr: $sym_name,
                      Wasm_FuncTypeAttr: $functionType,

--- a/mlir/include/mlir/Dialect/WebAssembly/IR/WebAssemblyOps.td
+++ b/mlir/include/mlir/Dialect/WebAssembly/IR/WebAssemblyOps.td
@@ -77,6 +77,20 @@ def Wasm_FuncOp : Wasm_Op<"func", [
     DeclareOpInterfaceMethods<FunctionOpInterface>,
     IsolatedFromAbove,
     Symbol]> {
+  let description = [{
+    Represents a wasm function definition.
+
+    In Wasm function, locals and function arguments are interchangeable.
+    They are for instance both accessed using `local.get` instruction.
+
+    In the other hand, function type is defined as a a pair of tuples of Wasm value types.
+    To model this, the wasm.func operation has:
+
+    - A function type that represents the corresponding wasm type (tuples of value types)
+
+    - Arguments of the entry block of type `!wasm<local T>`, with T the corresponding type
+     in thr function type.
+  }];
   let arguments = (ins SymbolNameAttr: $sym_name,
                      Wasm_FuncTypeAttr: $functionType,
                      OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -84,6 +98,10 @@ def Wasm_FuncOp : Wasm_Op<"func", [
                      DefaultValuedAttr<StrAttr, "\"nested\"">:$sym_visibility);
   let regions = (region AnyRegion: $body);
   let extraClassDeclaration = [{
+
+    /// Create the entry block for the function with parameters wrapped in local ref.
+    ::mlir::Block* addEntryBlock();
+
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods
     //===------------------------------------------------------------------===//
@@ -92,6 +110,8 @@ def Wasm_FuncOp : Wasm_Op<"func", [
     /// return null in the case of an external callable object, e.g. an external
     /// function.
     ::mlir::Region *getCallableRegion() { return isExternal() ? nullptr : &getBody(); }
+
+    ::mlir::LogicalResult verifyBody();
 
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
@@ -236,48 +256,33 @@ def Wasm_LocalOp : Wasm_Op<"local", [
   let summary = "Declaration of local variable";
   let arguments = (ins Wasm_ValTypeAttr: $type);
   let results = (outs Wasm_LocalRef: $result);
-  let assemblyFormat = "$type attr-dict";
-}
-
-def Wasm_LocalFromArgOp : Wasm_Op<"local_from_arg", [
-    ParentOneOf<["FuncOp"]>,
-    SameOperandsAndResultElementType,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Declaration of local variable storage from block argument";
-  let description = [{
-    Wasm locals includes the function arguments.
-    As they can be overriden in different path, they should be converted to memref.
-    This op is not a counterpart to any Wasm existing op.
-  }];
-  let arguments = (ins Wasm_ValType: $blockInput);
-  let results = (outs Wasm_LocalRef: $result);
-  let assemblyFormat = "$blockInput `:` type($blockInput) attr-dict";
+  let assemblyFormat = "`of` `type` $type attr-dict";
 }
 
 def Wasm_LocalGetOp : Wasm_Op<"local_get", [
-    SameOperandsAndResultElementType,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Set local to value and return the operand.";
   let arguments = (ins Wasm_LocalRef: $localVar);
   let results = (outs Wasm_ValType: $result);
   let assemblyFormat = "$localVar `:` type($localVar) attr-dict";
+  let hasVerifier = 1;
 }
 
-def Wasm_LocalSetOp : Wasm_Op<"local_set",[
-    SameOperandsElementType]> {
+def Wasm_LocalSetOp : Wasm_Op<"local_set"> {
   let summary = "Set local to given value";
   let arguments = (ins Wasm_LocalRef: $localVar,
                        Wasm_ValType: $value);
+  let hasVerifier = 1;
   let assemblyFormat = "$localVar `:` type($localVar) `to` $value `:` type($value) attr-dict";
 }
 
 def Wasm_LocalTeeOp : Wasm_Op<"local_tee", [
-    SameOperandsAndResultElementType,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Set local to value and return the operand.";
   let arguments = (ins Wasm_LocalRef: $localVar,
                        Wasm_ValType: $value);
   let results = (outs Wasm_ValType: $result);
+  let hasVerifier = 1;
   let assemblyFormat = "$localVar `:` type($localVar) `to` $value `:` type($value) attr-dict";
 }
 

--- a/mlir/include/mlir/Dialect/WebAssembly/IR/WebAssemblyTypes.td
+++ b/mlir/include/mlir/Dialect/WebAssembly/IR/WebAssemblyTypes.td
@@ -56,14 +56,21 @@ def Wasm_LimitType : Wasm_Type<"Limit", "limit"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def Wasm_LocalRef : Wasm_Type<"LocalRef", "local"> {
+  let summary = "Type of a local variable";
+  let parameters = (ins Wasm_ValType: $elementType);
+  let assemblyFormat = "`ref` `to` $elementType";
+   let builders = [TypeBuilderWithInferredContext<(ins "Type":$typeParam), [{
+      return get(typeParam.getContext(), typeParam);
+    }]>,];
+}
+
 def Wasm_TableType : Wasm_Type<"Table", "tabletype"> {
   let summary = "Wasm table type";
   let parameters = (ins Wasm_RefType:$reference,
                        Wasm_LimitType:$limit);
   let assemblyFormat = "$reference $limit";
 }
-
-def Wasm_LocalRef : MemRefRankOf<[Wasm_ValType], [0]>;
 
 def Wasm_FuncTypeAttr : TypeAttrOf<Wasm_FuncType>;
 def Wasm_LimitTypeAttr : TypeAttrOf<Wasm_LimitType>;

--- a/mlir/lib/Conversion/RaiseWasm/RaiseWasmMLIR.cpp
+++ b/mlir/lib/Conversion/RaiseWasm/RaiseWasmMLIR.cpp
@@ -343,8 +343,11 @@ struct WasmFuncOpConversion : OpConversionPattern<FuncOp> {
           ifOp.getInputs());
     }
 
-    template<typename LevelType>
-    LogicalResult replaceNestLevelWithBranchWrapper(WasmLabelLevelInterface nestingOp, llvm::ArrayRef<Block*> regionsToEntry, ConversionPatternRewriter& rewriter) {
+    template <typename LevelType>
+    LogicalResult
+    replaceNestLevelWithBranchWrapper(WasmLabelLevelInterface nestingOp,
+                                      llvm::ArrayRef<Block *> regionsToEntry,
+                                      ConversionPatternRewriter &rewriter) {
       auto cast = dyn_cast<LevelType>(nestingOp.getOperation());
       if (!cast)
         return failure();
@@ -480,6 +483,17 @@ struct WasmFuncOpConversion : OpConversionPattern<FuncOp> {
         funcOp->getLoc(), funcOp.getSymName(), funcOp.getFunctionType());
     rewriter.cloneRegionBefore(funcOp.getBody(), newFunc.getBody(),
                                newFunc.getBody().end());
+    Block *oldEntryBlock = &newFunc.getBody().front();
+    auto blockArgTypes = oldEntryBlock->getArgumentTypes();
+    TypeConverter::SignatureConversion sC{oldEntryBlock->getNumArguments()};
+    for (size_t i = 0; i < blockArgTypes.size(); ++i) {
+      auto argType = dyn_cast<LocalRefType>(blockArgTypes[i]);
+      if (!argType)
+        return failure();
+      sC.addInputs(i, argType.getElementType());
+    }
+
+    rewriter.applySignatureConversion(oldEntryBlock, sC, getTypeConverter());
     rewriter.replaceOp(funcOp, newFunc);
     CFRewriterVisitor cfRewriter{newFunc};
     return cfRewriter.rewrite(rewriter);
@@ -644,22 +658,6 @@ struct WasmLocalConversion : OpConversionPattern<LocalOp> {
   }
 };
 
-struct WasmLocalFromArgConversion : OpConversionPattern<LocalFromArgOp> {
-  using OpConversionPattern::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(LocalFromArgOp localFromArgOp,
-                  LocalFromArgOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto alloca = rewriter.replaceOpWithNewOp<memref::AllocaOp>(
-        localFromArgOp,
-        MemRefType::get({}, localFromArgOp.getBlockInput().getType()));
-    rewriter.create<memref::StoreOp>(localFromArgOp->getLoc(),
-                                     adaptor.getBlockInput(),
-                                     alloca.getResult());
-    return success();
-  }
-};
-
 struct WasmLocalGetConversion : OpConversionPattern<LocalGetOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -719,7 +717,16 @@ struct RaiseWasmMLIRPass
     RewritePatternSet patterns(&getContext());
     TypeConverter tc{};
     tc.addConversion([](Type type) -> std::optional<Type> { return type; });
-
+    tc.addConversion([](LocalRefType type)->std::optional<Type> {
+      return MemRefType::get({}, type.getElementType());
+    });
+    tc.addTargetMaterialization([](OpBuilder& builder, MemRefType destType, ValueRange values, Location loc)->Value{
+      if (values.size() != 1 || values.front().getType() != destType.getElementType())
+        return {};
+      auto localVar = builder.create<memref::AllocaOp>(loc, destType);
+      builder.create<memref::StoreOp>(loc, values.front(), localVar.getResult());
+      return localVar.getResult();
+    });
     populateRaiseWasmMLIRConversionPatterns(tc, patterns);
 
     llvm::DenseMap<StringAttr, StringAttr> idxSymToImportSym{};
@@ -777,7 +784,6 @@ void mlir::populateRaiseWasmMLIRConversionPatterns(
            WasmLeSIOpConversion,
            WasmLeUIOpConversion,
            WasmLocalConversion,
-           WasmLocalFromArgConversion,
            WasmLocalGetConversion,
            WasmLocalSetConversion,
            WasmLocalTeeConversion,

--- a/mlir/lib/Conversion/RaiseWasm/RaiseWasmMLIR.cpp
+++ b/mlir/lib/Conversion/RaiseWasm/RaiseWasmMLIR.cpp
@@ -486,7 +486,8 @@ struct WasmFuncOpConversion : OpConversionPattern<FuncOp> {
     Block *oldEntryBlock = &newFunc.getBody().front();
     auto blockArgTypes = oldEntryBlock->getArgumentTypes();
     TypeConverter::SignatureConversion sC{oldEntryBlock->getNumArguments()};
-    for (size_t i = 0; i < blockArgTypes.size(); ++i) {
+    auto numArgs = blockArgTypes.size();
+    for (size_t i = 0; i < numArgs; ++i) {
       auto argType = dyn_cast<LocalRefType>(blockArgTypes[i]);
       if (!argType)
         return failure();

--- a/mlir/lib/Dialect/WebAssembly/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/WebAssembly/IR/CMakeLists.txt
@@ -18,4 +18,7 @@ add_mlir_dialect_library(MLIRWasmDialect
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRSupport
+
+  PRIVATE
+  MLIRFunctionInterfaces
   )

--- a/mlir/lib/Dialect/WebAssembly/IR/WebAssemblyOps.cpp
+++ b/mlir/lib/Dialect/WebAssembly/IR/WebAssemblyOps.cpp
@@ -30,7 +30,7 @@ namespace {
 inline LogicalResult inferTeeGetResType(ValueRange operands, ::llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
   if (operands.empty())
     return failure();
-  auto opType = llvm::dyn_cast<MemRefType>(operands.front().getType());
+  auto opType = llvm::dyn_cast<LocalRefType>(operands.front().getType());
   if (!opType)
     return failure();
   inferredReturnTypes.push_back(opType.getElementType());
@@ -93,6 +93,18 @@ Block *BlockReturnOp::getTarget() {
 // FuncOp
 //===----------------------------------------------------------------------===//
 
+Block* FuncOp::addEntryBlock() {
+  if (!getBody().empty()) {
+    emitError("Adding entry block to a FuncOp which already has one.");
+    return &getBody().front();
+  }
+  Block &block = getBody().emplaceBlock();
+  for (auto argType : getFunctionType().getInputs()) {
+    block.addArgument(LocalRefType::get(argType), getLoc());
+  }
+  return &block;
+}
+
 void FuncOp::build(::mlir::OpBuilder &odsBuilder,
                                ::mlir::OperationState &odsState,
                                llvm::StringRef symbol, FunctionType funcType) {
@@ -104,14 +116,52 @@ void FuncOp::build(::mlir::OpBuilder &odsBuilder,
 
 ParseResult FuncOp::parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result) {
   auto buildFuncType =
-      [](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
+      [&parser](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
          function_interface_impl::VariadicFlag,
-         std::string &) { return builder.getFunctionType(argTypes, results); };
+         std::string &) {
+
+          llvm::SmallVector<Type> argTypesWithoutLocal{};
+          argTypesWithoutLocal.reserve(argTypes.size());
+          llvm::for_each(argTypes, [&parser, &argTypesWithoutLocal](Type argType){
+            auto refType = dyn_cast<LocalRefType>(argType);
+            auto loc = parser.getEncodedSourceLoc(parser.getCurrentLocation());
+            if (!refType) {
+              mlir::emitError(loc, "Invalid type for wasm.func argument. Expecting !wasm<local T>, got ") << argType << ".";
+              return;
+            }
+            argTypesWithoutLocal.push_back(refType.getElementType());
+          });
+
+          return builder.getFunctionType(argTypesWithoutLocal, results); };
 
   return function_interface_impl::parseFunctionOp(
       parser, result, /*allowVariadic=*/false,
       getFunctionTypeAttrName(result.name), buildFuncType,
       getArgAttrsAttrName(result.name), getResAttrsAttrName(result.name));
+}
+
+LogicalResult FuncOp::verifyBody() {
+  if (getBody().empty())
+    return success();
+  Block &entry = getBody().front();
+  if (entry.getNumArguments() != getFunctionType().getNumInputs())
+    return emitError("Entry block should have same number of arguments than "
+                     "function type. Function type has ")
+           << getFunctionType().getNumInputs() << ", entry block has "
+           << entry.getNumArguments() << ".";
+
+  for (auto [argNo, funcSignatureType, blockType] : llvm::enumerate(getFunctionType().getInputs(), entry.getArgumentTypes())) {
+    auto blockLocalRefType = dyn_cast<LocalRefType>(blockType);
+    if (!blockLocalRefType)
+      return emitError("Entry block argument type should be LocalRefType, got ")
+             << blockType << " for block argument " << argNo << ".";
+    if (blockLocalRefType.getElementType() != funcSignatureType)
+      return emitError("Func argument type #")
+             << argNo << "(" << funcSignatureType
+             << ") doesn't match entry block referenced type ("
+             << blockLocalRefType.getElementType() << ").";
+  }
+  return success();
 }
 
 void FuncOp::print(OpAsmPrinter &p) {
@@ -283,22 +333,7 @@ LogicalResult LocalOp::inferReturnTypes(
   auto type = adaptor.getTypeAttr();
   if (!type)
       return failure();
-  inferredReturnTypes.push_back(MemRefType::get({}, type.getValue()));
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// LocalFromArgOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult LocalFromArgOp::inferReturnTypes(
-    MLIRContext *context, ::std::optional<Location> location,
-    ValueRange operands, DictionaryAttr attributes, OpaqueProperties properties,
-    RegionRange regions, ::llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
-  if (operands.empty())
-    return failure();
-  Type opType = operands.front().getType();
-  auto resType = MemRefType::get({}, opType);
+  auto resType = LocalRefType::get(type.getContext(), type.getValue());
   inferredReturnTypes.push_back(resType);
   return success();
 }
@@ -314,6 +349,20 @@ LogicalResult LocalGetOp::inferReturnTypes(
   return inferTeeGetResType(operands, inferredReturnTypes);
 }
 
+LogicalResult LocalGetOp::verify() {
+  return success(getLocalVar().getType().getElementType() ==
+                 getResult().getType());
+}
+
+//===----------------------------------------------------------------------===//
+// LocalSetOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LocalSetOp::verify() {
+  return success(getLocalVar().getType().getElementType() ==
+                 getValue().getType());
+}
+
 //===----------------------------------------------------------------------===//
 // LocalTeeOp
 //===----------------------------------------------------------------------===//
@@ -323,6 +372,12 @@ LogicalResult LocalTeeOp::inferReturnTypes(
     ValueRange operands, DictionaryAttr attributes, OpaqueProperties properties,
     RegionRange regions, ::llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
   return inferTeeGetResType(operands, inferredReturnTypes);
+}
+
+LogicalResult LocalTeeOp::verify() {
+  return success(getLocalVar().getType().getElementType() ==
+                     getValue().getType() &&
+                 getValue().getType() == getResult().getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/WebAssembly/IR/WebAssemblyOps.cpp
+++ b/mlir/lib/Dialect/WebAssembly/IR/WebAssemblyOps.cpp
@@ -99,9 +99,8 @@ Block* FuncOp::addEntryBlock() {
     return &getBody().front();
   }
   Block &block = getBody().emplaceBlock();
-  for (auto argType : getFunctionType().getInputs()) {
+  for (auto argType : getFunctionType().getInputs())
     block.addArgument(LocalRefType::get(argType), getLoc());
-  }
   return &block;
 }
 
@@ -145,7 +144,7 @@ LogicalResult FuncOp::verifyBody() {
     return success();
   Block &entry = getBody().front();
   if (entry.getNumArguments() != getFunctionType().getNumInputs())
-    return emitError("Entry block should have same number of arguments than "
+    return emitError("Entry block should have same number of arguments as "
                      "function type. Function type has ")
            << getFunctionType().getNumInputs() << ", entry block has "
            << entry.getNumArguments() << ".";

--- a/mlir/lib/Dialect/WebAssembly/IR/WebAssemblyTypes.cpp
+++ b/mlir/lib/Dialect/WebAssembly/IR/WebAssemblyTypes.cpp
@@ -4,7 +4,6 @@
 #include "llvm/Support/LogicalResult.h"
 
 #include <optional>
-#include <sstream>
 
 namespace mlir {
 namespace wasm {

--- a/mlir/lib/Target/Wasm/TranslateFromWasm.cpp
+++ b/mlir/lib/Target/Wasm/TranslateFromWasm.cpp
@@ -247,7 +247,7 @@ private:
   llvm::SmallVector<LabelLevel> labelLevel;
 };
 
-using local_val_t = TypedValue<MemRefType>;
+using local_val_t = TypedValue<wasm::LocalRefType>;
 
 class ExpressionParser {
 public:
@@ -689,8 +689,7 @@ public:
       return failure();
     OpBuilder builder{&func.getBody().front().back()};
     for (auto arg : block.getArguments())
-      locals.push_back(
-          builder.create<LocalFromArgOp>(func->getLoc(), arg).getResult());
+      locals.push_back(cast<TypedValue<LocalRefType>>(arg));
     // Declare the local ops
     auto nVarVec = *localVecSize;
     for (size_t i = 0; i < nVarVec; ++i) {

--- a/mlir/test/Conversion/RaiseWasm/wasm-abs-to-math-abs.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-abs-to-math-abs.mlir
@@ -1,21 +1,27 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @abs_f32(
-// CHECK-SAME:      %[[VAL_0:.*]]: f32) -> f32 {
-// CHECK:           %[[VAL_1:.*]] = math.absf %[[VAL_0]] : f32
-// CHECK:           return %[[VAL_1]] : f32
-// CHECK:         }
-wasm.func nested @abs_f32(%arg0: f32) -> f32 {
-    %op = wasm.abs %arg0 : f32
+// CHECK-SAME:      %[[ARG0:.*]]: f32) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = math.absf %[[VAL_1]] : f32
+// CHECK:           return %[[VAL_2]] : f32
+wasm.func nested @abs_f32(%arg0: !wasm<local ref to f32>) -> f32 {
+    %val = wasm.local_get %arg0 : ref to f32
+    %op = wasm.abs %val : f32
     wasm.return %op : f32
 }
 
 // CHECK-LABEL:   func.func @abs_f64(
-// CHECK-SAME:      %[[VAL_0:.*]]: f64) -> f64 {
-// CHECK:           %[[VAL_1:.*]] = math.absf %[[VAL_0]] : f64
-// CHECK:           return %[[VAL_1]] : f64
-// CHECK:         }
-wasm.func nested @abs_f64(%arg0: f64) -> f64 {
-    %op = wasm.abs %arg0 : f64
+// CHECK-SAME:      %[[ARG0:.*]]: f64) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = math.absf %[[VAL_1]] : f64
+// CHECK:           return %[[VAL_2]] : f64
+wasm.func nested @abs_f64(%arg0: !wasm<local ref to f64>) -> f64 {
+    %val = wasm.local_get %arg0 : ref to f64
+    %op = wasm.abs %val : f64
     wasm.return %op : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-add-to-arith-add.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-add-to-arith-add.mlir
@@ -1,47 +1,79 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir | FileCheck %s
 
 // CHECK-LABEL:   func.func @func_1(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i32) -> i32 {
-wasm.func nested @func_1(%arg0: i32, %arg1: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i32
-%0 = wasm.add %arg0 %arg1 : i32
-// CHECK:           return %[[VAL_2]] : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32,
+// CHECK-SAME:                      %[[ARG1:.*]]: i32) -> i32 {
+wasm.func nested @func_1(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+%v1 = wasm.local_get %arg1 : ref to i32
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : i32
+%0 = wasm.add %v0 %v1 : i32
+// CHECK:           return %[[VAL_4]] : i32
 wasm.return %0 : i32
 }
 
 // -----
 
 // CHECK-LABEL:   func.func @func_2(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i64) -> i64 {
-wasm.func nested @func_2(%arg0: i64, %arg1: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i64
-%0 = wasm.add %arg0 %arg1 : i64
-// CHECK:           return %[[VAL_2]] : i64
+// CHECK-SAME:                      %[[ARG0:.*]]: i64,
+// CHECK-SAME:                      %[[ARG1:.*]]: i64) -> i64 {
+wasm.func nested @func_2(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+%v0 = wasm.local_get %arg0 : ref to i64
+%v1 = wasm.local_get %arg1 : ref to i64
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : i64
+%0 = wasm.add %v0 %v1 : i64
+// CHECK:           return %[[VAL_4]] : i64
 wasm.return %0 : i64
 }
 
 // -----
 
 // CHECK-LABEL:   func.func @func_3(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f32) -> f32 {
-wasm.func nested @func_3(%arg0: f32, %arg1: f32) -> f32 {
-// CHECK:           %[[VAL_2:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : f32
-%0 = wasm.add %arg0 %arg1 : f32
-// CHECK:           return %[[VAL_2]] : f32
+// CHECK-SAME:                      %[[ARG0:.*]]: f32,
+// CHECK-SAME:                      %[[ARG1:.*]]: f32) -> f32 {
+wasm.func nested @func_3(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+%v0 = wasm.local_get %arg0 : ref to f32
+%v1 = wasm.local_get %arg1 : ref to f32
+// CHECK:           %[[VAL_4:.*]] = arith.addf %[[VAL_2]], %[[VAL_3]] : f32
+%0 = wasm.add %v0 %v1 : f32
+// CHECK:           return %[[VAL_4]] : f32
 wasm.return %0 : f32
 }
 
 // -----
 
 // CHECK-LABEL:   func.func @func_4(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f64) -> f64 {
-wasm.func nested @func_4(%arg0: f64, %arg1: f64) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : f64
-%0 = wasm.add %arg0 %arg1 : f64
-// CHECK:           return %[[VAL_2]] : f64
+// CHECK-SAME:                      %[[ARG0:.*]]: f64,
+// CHECK-SAME:                      %[[ARG1:.*]]: f64) -> f64 {
+wasm.func nested @func_4(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+%v0 = wasm.local_get %arg0 : ref to f64
+%v1 = wasm.local_get %arg1 : ref to f64
+// CHECK:           %[[VAL_4:.*]] = arith.addf %[[VAL_2]], %[[VAL_3]] : f64
+%0 = wasm.add %v0 %v1 : f64
+// CHECK:           return %[[VAL_4]] : f64
 wasm.return %0 : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-and-to-arith-and.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-and-to-arith-and.mlir
@@ -2,21 +2,37 @@
 
 
 // CHECK-LABEL:   func.func @and_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @and_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.and %arg0 %arg1 : i32
-    wasm.return %op : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32,
+// CHECK-SAME:                      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.andi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @and_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    %and = wasm.and %v0 %v1 : i32
+    wasm.return %and : i32
 }
 
 // CHECK-LABEL:   func.func @and_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @and_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.and %arg0 %arg1 : i64
-    wasm.return %op : i64
+// CHECK-SAME:                      %[[ARG0:.*]]: i64,
+// CHECK-SAME:                      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.andi %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @and_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    %and = wasm.and %v0 %v1 : i64
+    wasm.return %and : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-blocks-to-cf.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-blocks-to-cf.mlir
@@ -2,19 +2,19 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir --canonicalize -o - | FileCheck --check-prefix=CHECK_CANONICALIZED %s
 
 // CHECK-LABEL:   func.func @i_am_a_block(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = arith.constant 17 : i32
-// CHECK:           memref.store %[[VAL_2]], %[[VAL_1]][] : memref<i32>
+// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = arith.constant 17 : i32
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_0]][] : memref<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_3:.*]] = arith.constant 42 : i32
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = arith.constant 42 : i32
+// CHECK:           memref.store %[[VAL_2]], %[[VAL_0]][] : memref<i32>
 // CHECK:           cf.br ^bb2
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_4:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           return %[[VAL_4]] : i32
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           return %[[VAL_3]] : i32
 
 // CHECK_CANONICALIZED-LABEL:   func.func @i_am_a_block(
 // CHECK_CANONICALIZED-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
@@ -24,47 +24,43 @@
 // CHECK_CANONICALIZED-NOT:       memref.store
 // CHECK_CANONICALIZED:           %[[VAL_4:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK_CANONICALIZED:           return %[[VAL_4]] : i32
-wasm.func @i_am_a_block(%arg0 : i32) -> i32 {
-  %0 = wasm.local_from_arg %arg0 : i32
+wasm.func @i_am_a_block(%arg0 : !wasm<local ref to i32>) -> i32 {
   %1 = wasm.const 17 : i32
-  wasm.local_set %0 : memref<i32> to %1 : i32
+  wasm.local_set %arg0 : ref to i32 to %1 : i32
   wasm.block : {
     %2 = wasm.const 42 : i32
-    wasm.local_set %0 : memref<i32> to %2 : i32
+    wasm.local_set %arg0 : ref to i32 to %2 : i32
     wasm.block_return
   }> ^bb1
   ^bb1:
-  %res = wasm.local_get %0 : memref<i32>
+  %res = wasm.local_get %arg0 : ref to i32
   wasm.return %res : i32
 }
 
 
 // CHECK-LABEL:   func.func @func_0(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32) {
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32) {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i32
 // CHECK:           cf.br ^bb2
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_4:.*]] = arith.constant 3 : i32
+// CHECK:           %[[VAL_2:.*]] = arith.constant 3 : i32
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_5:.*]] = arith.constant 4 : i32
+// CHECK:           %[[VAL_3:.*]] = arith.constant 4 : i32
 // CHECK:           cf.br ^bb4
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_6:.*]] = arith.constant 5 : i32
+// CHECK:           %[[VAL_4:.*]] = arith.constant 5 : i32
 // CHECK:           cf.br ^bb5
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_7:.*]] = arith.constant 6 : i32
+// CHECK:           %[[VAL_5:.*]] = arith.constant 6 : i32
 // CHECK:           cf.br ^bb6
 // CHECK:         ^bb6:
-// CHECK:           %[[VAL_8:.*]] = arith.constant 7 : i32
+// CHECK:           %[[VAL_6:.*]] = arith.constant 7 : i32
 // CHECK:           return
-wasm.func nested @func_0(%arg0: i32) {
-  %0 = wasm.local_from_arg %arg0 : i32
+wasm.func nested @func_0(%arg0: !wasm<local ref to i32>) {
   %1 = wasm.const 1: i32
   wasm.block : {
     %2 = wasm.const 2: i32
@@ -237,43 +233,42 @@ wasm.func nested @branch_if_continue() -> i32 {
 }
 
 // CHECK-LABEL:   func.func @if(
-// CHECK-SAME:                  %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_4:.*]] = arith.andi %[[VAL_2]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_5]] : i32
-// CHECK:           cf.cond_br %[[VAL_6]], ^bb1, ^bb2
+// CHECK-SAME:                  %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i32
+// CHECK:           cf.cond_br %[[VAL_5]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_8:.*]] = arith.constant 3 : i32
-// CHECK:           %[[VAL_9:.*]] = arith.muli %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_10:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_9]], %[[VAL_10]] : i32
-// CHECK:           cf.br ^bb3(%[[VAL_11]] : i32)
+// CHECK:           %[[VAL_6:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_7:.*]] = arith.constant 3 : i32
+// CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_9:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:           cf.br ^bb3(%[[VAL_10]] : i32)
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_13:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_14:.*]] = arith.shrui %[[VAL_12]], %[[VAL_13]] : i32
-// CHECK:           cf.br ^bb3(%[[VAL_14]] : i32)
-// CHECK:         ^bb3(%[[VAL_15:.*]]: i32):
-// CHECK:           return %[[VAL_15]] : i32
-wasm.func nested @if(%arg0: i32) -> i32 {
-  %0 = wasm.local_from_arg %arg0 : i32
-  %1 = wasm.local_get %0 : memref<i32>
+// CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_12:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_13:.*]] = arith.shrui %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:           cf.br ^bb3(%[[VAL_13]] : i32)
+// CHECK:         ^bb3(%[[VAL_14:.*]]: i32):
+// CHECK:           return %[[VAL_14]] : i32
+wasm.func nested @if(%arg0: !wasm<local ref to i32>) -> i32 {
+  %1 = wasm.local_get %arg0 : ref to i32
   %2 = wasm.const 1 : i32
   %3 = wasm.and %1 %2 : i32
   "wasm.if"(%3)[^bb1] ({
-    %5 = wasm.local_get %0 : memref<i32>
+    %5 = wasm.local_get %arg0 : ref to i32
     %6 = wasm.const 3 : i32
     %7 = wasm.mul %5 %6 : i32
     %8 = wasm.const 1 : i32
     %9 = wasm.add %7 %8 : i32
     wasm.block_return %9 : i32
   }, {
-    %5 = wasm.local_get %0 : memref<i32>
+    %5 = wasm.local_get %arg0 : ref to i32
     %6 = wasm.const 1 : i32
     %7 = wasm.shr_u %5 by %6 bits : i32
     wasm.block_return %7 : i32
@@ -283,26 +278,25 @@ wasm.func nested @if(%arg0: i32) -> i32 {
 }
 
 // CHECK-LABEL:   func.func @if_else(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_4:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_5:.*]] = arith.andi %[[VAL_3]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_7:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           cf.cond_br %[[VAL_7]], ^bb1(%[[VAL_2]] : i32), ^bb2(%[[VAL_2]] : i32)
-// CHECK:         ^bb1(%[[VAL_8:.*]]: i32):
-// CHECK:           %[[VAL_9:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_8]], %[[VAL_9]] : i32
-// CHECK:           cf.br ^bb2(%[[VAL_10]] : i32)
-// CHECK:         ^bb2(%[[VAL_11:.*]]: i32):
-// CHECK:           return %[[VAL_11]] : i32
-wasm.func nested @if_else(%arg0: i32) -> i32 {
-  %0 = wasm.local_from_arg %arg0 : i32
-  %1 = wasm.local_get %0 : memref<i32>
-  %2 = wasm.local_get %0 : memref<i32>
+// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_4:.*]] = arith.andi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_5]] : i32
+// CHECK:           cf.cond_br %[[VAL_6]], ^bb1(%[[VAL_1]] : i32), ^bb2(%[[VAL_1]] : i32)
+// CHECK:         ^bb1(%[[VAL_7:.*]]: i32):
+// CHECK:           %[[VAL_8:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           cf.br ^bb2(%[[VAL_9]] : i32)
+// CHECK:         ^bb2(%[[VAL_10:.*]]: i32):
+// CHECK:           return %[[VAL_10]] : i32
+wasm.func nested @if_else(%arg0: !wasm<local ref to i32>) -> i32 {
+  %1 = wasm.local_get %arg0 : ref to i32
+  %2 = wasm.local_get %arg0 : ref to i32
   %3 = wasm.const 1 : i32
   %4 = wasm.and %2 %3 : i32
   "wasm.if"(%4, %1)[^bb1] ({
@@ -317,41 +311,40 @@ wasm.func nested @if_else(%arg0: i32) -> i32 {
 }
 
 // CHECK-LABEL:   func.func @if_if(
-// CHECK-SAME:                     %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = math.cttz %[[VAL_2]] : i32
-// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i32
-// CHECK:           cf.cond_br %[[VAL_5]], ^bb1, ^bb4
+// CHECK-SAME:                     %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = math.cttz %[[VAL_1]] : i32
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_4:.*]] = arith.cmpi ne, %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           cf.cond_br %[[VAL_4]], ^bb1, ^bb4
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_6:.*]] = arith.constant 2 : i32
-// CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_8:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_9:.*]] = arith.shrui %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_10:.*]] = math.cttz %[[VAL_9]] : i32
-// CHECK:           %[[VAL_11:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_12:.*]] = arith.cmpi ne, %[[VAL_10]], %[[VAL_11]] : i32
-// CHECK:           cf.cond_br %[[VAL_12]], ^bb2(%[[VAL_6]] : i32), ^bb3(%[[VAL_6]] : i32)
-// CHECK:         ^bb2(%[[VAL_13:.*]]: i32):
-// CHECK:           %[[VAL_14:.*]] = arith.constant 2 : i32
-// CHECK:           %[[VAL_15:.*]] = arith.addi %[[VAL_13]], %[[VAL_14]] : i32
-// CHECK:           cf.br ^bb3(%[[VAL_15]] : i32)
-// CHECK:         ^bb3(%[[VAL_16:.*]]: i32):
-// CHECK:           cf.br ^bb5(%[[VAL_16]] : i32)
+// CHECK:           %[[VAL_5:.*]] = arith.constant 2 : i32
+// CHECK:           %[[VAL_6:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_7:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_8:.*]] = arith.shrui %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_9:.*]] = math.cttz %[[VAL_8]] : i32
+// CHECK:           %[[VAL_10:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_11:.*]] = arith.cmpi ne, %[[VAL_9]], %[[VAL_10]] : i32
+// CHECK:           cf.cond_br %[[VAL_11]], ^bb2(%[[VAL_5]] : i32), ^bb3(%[[VAL_5]] : i32)
+// CHECK:         ^bb2(%[[VAL_12:.*]]: i32):
+// CHECK:           %[[VAL_13:.*]] = arith.constant 2 : i32
+// CHECK:           %[[VAL_14:.*]] = arith.addi %[[VAL_12]], %[[VAL_13]] : i32
+// CHECK:           cf.br ^bb3(%[[VAL_14]] : i32)
+// CHECK:         ^bb3(%[[VAL_15:.*]]: i32):
+// CHECK:           cf.br ^bb5(%[[VAL_15]] : i32)
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_17:.*]] = arith.constant 1 : i32
-// CHECK:           cf.br ^bb5(%[[VAL_17]] : i32)
-// CHECK:         ^bb5(%[[VAL_18:.*]]: i32):
-// CHECK:           return %[[VAL_18]] : i32
-wasm.func nested @if_if(%arg0: i32) -> i32 {
-  %0 = wasm.local_from_arg %arg0 : i32
-  %1 = wasm.local_get %0 : memref<i32>
+// CHECK:           %[[VAL_16:.*]] = arith.constant 1 : i32
+// CHECK:           cf.br ^bb5(%[[VAL_16]] : i32)
+// CHECK:         ^bb5(%[[VAL_17:.*]]: i32):
+// CHECK:           return %[[VAL_17]] : i32
+wasm.func nested @if_if(%arg0: !wasm<local ref to i32>) -> i32 {
+  %1 = wasm.local_get %arg0 : ref to i32
   %2 = wasm.ctz %1 : i32
   "wasm.if"(%2)[^bb1] ({
     %4 = wasm.const 2 : i32
-    %5 = wasm.local_get %0 : memref<i32>
+    %5 = wasm.local_get %arg0 : ref to i32
     %6 = wasm.const 1 : i32
     %7 = wasm.shr_u %5 by %6 bits : i32
     %8 = wasm.ctz %7 : i32

--- a/mlir/test/Conversion/RaiseWasm/wasm-clz-to-math-clz.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-clz-to-math-clz.mlir
@@ -1,19 +1,27 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @clz_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = math.ctlz %[[VAL_0]] : i32
-// CHECK:           return %[[VAL_1]] : i32
-wasm.func nested @clz_i32(%arg0: i32) -> i32 {
-    %op = wasm.clz %arg0 : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = math.ctlz %[[VAL_1]] : i32
+// CHECK:           return %[[VAL_2]] : i32
+wasm.func nested @clz_i32(%arg0: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %op = wasm.clz %v0 : i32
     wasm.return %op : i32
 }
 
 // CHECK-LABEL:   func.func @clz_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_1:.*]] = math.ctlz %[[VAL_0]] : i64
-// CHECK:           return %[[VAL_1]] : i64
-wasm.func nested @clz_i64(%arg0: i64) -> i64 {
-    %op = wasm.clz %arg0 : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = math.ctlz %[[VAL_1]] : i64
+// CHECK:           return %[[VAL_2]] : i64
+wasm.func nested @clz_i64(%arg0: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %op = wasm.clz %v0 : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-copysign-to-math-copysign.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-copysign-to-math-copysign.mlir
@@ -2,21 +2,37 @@
 
 
 // CHECK-LABEL:   func.func @copysign_f32(
-// CHECK-SAME:      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:      %[[VAL_1:.*]]: f32) -> f32 {
-// CHECK:           %[[VAL_2:.*]] = math.copysign %[[VAL_0]], %[[VAL_1]] : f32
-// CHECK:           return %[[VAL_2]] : f32
-wasm.func nested @copysign_f32(%arg0: f32, %arg1: f32) -> f32 {
-    %op = wasm.copysign %arg0 %arg1: f32
+// CHECK-SAME:      %[[ARG0:.*]]: f32,
+// CHECK-SAME:      %[[ARG1:.*]]: f32) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_4:.*]] = math.copysign %[[VAL_2]], %[[VAL_3]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+wasm.func nested @copysign_f32(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+    %v0 = wasm.local_get %arg0 : ref to f32
+    %v1 = wasm.local_get %arg1 : ref to f32
+    %op = wasm.copysign %v0 %v1: f32
     wasm.return %op : f32
 }
 
 // CHECK-LABEL:   func.func @copysign_f64(
-// CHECK-SAME:      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:      %[[VAL_1:.*]]: f64) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = math.copysign %[[VAL_0]], %[[VAL_1]] : f64
-// CHECK:           return %[[VAL_2]] : f64
-wasm.func nested @copysign_f64(%arg0: f64, %arg1: f64) -> f64 {
-    %op = wasm.copysign %arg0 %arg1: f64
+// CHECK-SAME:      %[[ARG0:.*]]: f64,
+// CHECK-SAME:      %[[ARG1:.*]]: f64) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_4:.*]] = math.copysign %[[VAL_2]], %[[VAL_3]] : f64
+// CHECK:           return %[[VAL_4]] : f64
+wasm.func nested @copysign_f64(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+    %v0 = wasm.local_get %arg0 : ref to f64
+    %v1 = wasm.local_get %arg1 : ref to f64
+    %op = wasm.copysign %v0 %v1: f64
     wasm.return %op : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-ctz-to-math-ctz.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-ctz-to-math-ctz.mlir
@@ -1,19 +1,27 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @ctz_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = math.cttz %[[VAL_0]] : i32
-// CHECK:           return %[[VAL_1]] : i32
-wasm.func nested @ctz_i32(%arg0: i32) -> i32 {
-    %op = wasm.ctz %arg0 : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = math.cttz %[[VAL_1]] : i32
+// CHECK:           return %[[VAL_2]] : i32
+wasm.func nested @ctz_i32(%arg0: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %op = wasm.ctz %v0 : i32
     wasm.return %op : i32
 }
 
 // CHECK-LABEL:   func.func @ctz_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_1:.*]] = math.cttz %[[VAL_0]] : i64
-// CHECK:           return %[[VAL_1]] : i64
-wasm.func nested @ctz_i64(%arg0: i64) -> i64 {
-    %op = wasm.ctz %arg0 : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = math.cttz %[[VAL_1]] : i64
+// CHECK:           return %[[VAL_2]] : i64
+wasm.func nested @ctz_i64(%arg0: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %op = wasm.ctz %v0 : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-div-to-arith-div.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-div-to-arith-div.mlir
@@ -1,70 +1,109 @@
 // RUN: mlir-opt %s --raise-wasm-mlir | FileCheck %s
 
 // CHECK-LABEL:   func.func @div_i32_si(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i32) -> i32 {
-wasm.func nested @div_i32_si(%arg0: i32, %arg1: i32) -> i32 {
-
-// CHECK:           %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : i32
-%0 = wasm.div_si %arg0 %arg1 : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.return %0 : i32
-}
-
-
-// CHECK-LABEL:   func.func @div_i32_ui(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i32) -> i32 {
-wasm.func nested @div_i32_ui(%arg0: i32, %arg1: i32) -> i32 {
-
-// CHECK:           %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : i32
-%0 = wasm.div_ui %arg0 %arg1 : i32
-// CHECK:           return %[[VAL_2]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+wasm.func nested @div_i32_si(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+%v1 = wasm.local_get %arg1 : ref to i32
+// CHECK:           %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : i32
+%0 = wasm.div_si %v0 %v1 : i32
+// CHECK:           return %[[VAL_4]] : i32
 wasm.return %0 : i32
 }
 
 // CHECK-LABEL:   func.func @div_i64_si(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i64) -> i64 {
-wasm.func nested @div_i64_si(%arg0: i64, %arg1: i64) -> i64 {
-
-// CHECK:           %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : i64
-%0 = wasm.div_si %arg0 %arg1 : i64
-// CHECK:           return %[[VAL_2]] : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+wasm.func nested @div_i64_si(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+%v0 = wasm.local_get %arg0 : ref to i64
+%v1 = wasm.local_get %arg1 : ref to i64
+// CHECK:           %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : i64
+%0 = wasm.div_si %v0 %v1 : i64
+// CHECK:           return %[[VAL_4]] : i64
 wasm.return %0 : i64
 }
 
+// CHECK-LABEL:   func.func @div_i32_ui(
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+wasm.func nested @div_i32_ui(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+%v1 = wasm.local_get %arg1 : ref to i32
+// CHECK:           %[[VAL_4:.*]] = arith.divui %[[VAL_2]], %[[VAL_3]] : i32
+%0 = wasm.div_ui %v0 %v1 : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.return %0 : i32
+}
 
 // CHECK-LABEL:   func.func @div_i64_ui(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i64) -> i64 {
-wasm.func nested @div_i64_ui(%arg0: i64, %arg1: i64) -> i64 {
-
-// CHECK:           %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : i64
-%0 = wasm.div_ui %arg0 %arg1 : i64
-// CHECK:           return %[[VAL_2]] : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+wasm.func nested @div_i64_ui(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+%v0 = wasm.local_get %arg0 : ref to i64
+%v1 = wasm.local_get %arg1 : ref to i64
+// CHECK:           %[[VAL_4:.*]] = arith.divui %[[VAL_2]], %[[VAL_3]] : i64
+%0 = wasm.div_ui %v0 %v1 : i64
+// CHECK:           return %[[VAL_4]] : i64
 wasm.return %0 : i64
 }
 
-
 // CHECK-LABEL:   func.func @div_f32(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f32) -> f32 {
-wasm.func nested @div_f32(%arg0: f32, %arg1: f32) -> f32 {
-
-// CHECK:           %[[VAL_2:.*]] = arith.divf %[[VAL_0]], %[[VAL_1]] : f32
-%0 = wasm.div %arg0 %arg1 : f32
-// CHECK:           return %[[VAL_2]] : f32
+// CHECK-SAME:      %[[ARG0:.*]]: f32,
+// CHECK-SAME:      %[[ARG1:.*]]: f32) -> f32 {
+wasm.func nested @div_f32(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+%v0 = wasm.local_get %arg0 : ref to f32
+%v1 = wasm.local_get %arg1 : ref to f32
+// CHECK:           %[[VAL_4:.*]] = arith.divf %[[VAL_2]], %[[VAL_3]] : f32
+%0 = wasm.div %v0 %v1 : f32
+// CHECK:           return %[[VAL_4]] : f32
 wasm.return %0 : f32
 }
 
 // CHECK-LABEL:   func.func @div_f64(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f64) -> f64 {
-wasm.func nested @div_f64(%arg0: f64, %arg1: f64) -> f64 {
-
-// CHECK:           %[[VAL_2:.*]] = arith.divf %[[VAL_0]], %[[VAL_1]] : f64
-%0 = wasm.div %arg0 %arg1 : f64
-// CHECK:           return %[[VAL_2]] : f64
+// CHECK-SAME:      %[[ARG0:.*]]: f64,
+// CHECK-SAME:      %[[ARG1:.*]]: f64) -> f64 {
+wasm.func nested @div_f64(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+%v0 = wasm.local_get %arg0 : ref to f64
+%v1 = wasm.local_get %arg1 : ref to f64
+// CHECK:           %[[VAL_4:.*]] = arith.divf %[[VAL_2]], %[[VAL_3]] : f64
+%0 = wasm.div %v0 %v1 : f64
+// CHECK:           return %[[VAL_4]] : f64
 wasm.return %0 : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-func-to-func.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-func-to-func.mlir
@@ -2,18 +2,24 @@
 
 
 // CHECK-LABEL:   func.func @callee(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32) -> i32 {
-wasm.func nested @callee(%arg0: i32) -> i32 {
-// CHECK-NEXT:           return %[[VAL_0]] : i32
-wasm.return %arg0 : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32) -> i32 {
+wasm.func nested @callee(%arg0: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+// CHECK:           return %[[VAL_1]] : i32
+wasm.return %v0 : i32
 }
 
-// CHECK-LABEL:   func.func @caller(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32) -> i32 {
-wasm.func nested @caller(%arg0: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = call @callee(%[[VAL_0]]) : (i32) -> i32
-%0 = wasm.call @callee (%arg0) : (i32) -> i32
-// CHECK:           return %[[VAL_1]] : i32
+wasm.func nested @caller(%arg0: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+// CHECK:           %[[VAL_2:.*]] = call @callee(%[[VAL_1]]) : (i32) -> i32
+%0 = wasm.call @callee (%v0) : (i32) -> i32
+// CHECK:           return %[[VAL_2]] : i32
 wasm.return %0 : i32
 }
 

--- a/mlir/test/Conversion/RaiseWasm/wasm-local-to-memref.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-local-to-memref.mlir
@@ -5,21 +5,21 @@ wasm.func nested @func_0() -> f32 {
 // CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_0]][] : memref<f32>
-  %0 = wasm.local f32
+  %0 = wasm.local of type f32
 // CHECK:           %[[VAL_2:.*]] = memref.alloca() : memref<f32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_2]][] : memref<f32>
-  %1 = wasm.local f32
+  %1 = wasm.local of type f32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 8.000000e+00 : f32
   %2 = wasm.const 8.000000e+00 : f32
 // CHECK:           memref.store %[[VAL_4]], %[[VAL_0]][] : memref<f32>
-  wasm.local_set %0 : memref<f32> to %2 : f32
+  wasm.local_set %0 : ref to f32 to %2 : f32
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_0]][] : memref<f32>
-  %3 = wasm.local_get %0 : memref<f32>
+  %3 = wasm.local_get %0 : ref to f32
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1.200000e+01 : f32
   %4 = wasm.const 1.200000e+01 : f32
 // CHECK:           memref.store %[[VAL_6]], %[[VAL_2]][] : memref<f32>
-  %5 = wasm.local_tee %1 : memref<f32> to %4 : f32
+  %5 = wasm.local_tee %1 : ref to f32 to %4 : f32
 // CHECK:           %[[VAL_7:.*]] = arith.addf %[[VAL_5]], %[[VAL_6]] : f32
   %6 = wasm.add %3 %5 : f32
 // CHECK:           return %[[VAL_7]] : f32
@@ -31,21 +31,21 @@ wasm.func nested @func_1() -> i32 {
 // CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_0]][] : memref<i32>
-  %0 = wasm.local i32
+  %0 = wasm.local of type i32
 // CHECK:           %[[VAL_2:.*]] = memref.alloca() : memref<i32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_2]][] : memref<i32>
-  %1 = wasm.local i32
+  %1 = wasm.local of type i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 8 : i32
   %2 = wasm.const 8 : i32
 // CHECK:           memref.store %[[VAL_4]], %[[VAL_0]][] : memref<i32>
-  wasm.local_set %0 : memref<i32> to %2 : i32
+  wasm.local_set %0 : ref to i32 to %2 : i32
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_0]][] : memref<i32>
-  %3 = wasm.local_get %0 : memref<i32>
+  %3 = wasm.local_get %0 : ref to i32
 // CHECK:           %[[VAL_6:.*]] = arith.constant 12 : i32
   %4 = wasm.const 12 : i32
 // CHECK:           memref.store %[[VAL_6]], %[[VAL_2]][] : memref<i32>
-  %5 = wasm.local_tee %1 : memref<i32> to %4 : i32
+  %5 = wasm.local_tee %1 : ref to i32 to %4 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_5]], %[[VAL_6]] : i32
   %6 = wasm.add %3 %5 : i32
 // CHECK:           return %[[VAL_7]] : i32
@@ -54,16 +54,15 @@ wasm.func nested @func_1() -> i32 {
 
 // CHECK-LABEL:   func.func @func_2(
 // CHECK-SAME:                      %[[VAL_0:.*]]: i32) -> i32 {
-wasm.func nested @func_2(%arg0: i32) -> i32 {
+wasm.func nested @func_2(%arg0: !wasm<local ref to i32>) -> i32 {
 // CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-  %0 = wasm.local_from_arg %arg0 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3 : i32
   %1 = wasm.const 3 : i32
 // CHECK:           memref.store %[[VAL_2]], %[[VAL_1]][] : memref<i32>
-  wasm.local_set %0 : memref<i32> to %1 : i32
+  wasm.local_set %arg0 : ref to i32 to %1 : i32
 // CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_1]][] : memref<i32>
-  %2 = wasm.local_get %0 : memref<i32>
+  %2 = wasm.local_get %arg0 : ref to i32
 // CHECK:           return %[[VAL_3]] : i32
   wasm.return %2 : i32
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-loop-to-cf.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-loop-to-cf.mlir
@@ -28,9 +28,9 @@ module {
 
 module {
   wasm.func nested @func_0() -> i32 {
-    %0 = wasm.local i32
+    %0 = wasm.local of type i32
     wasm.loop : {
-      %1 = wasm.local_get %0 : memref<i32>
+      %1 = wasm.local_get %0 : ref to i32
       %2 = wasm.const 10 : i32
       %3 = wasm.lt_si %1 %2 : i32 -> i32
       wasm.block_return %3 : i32
@@ -68,9 +68,9 @@ module {
 
 module {
   wasm.func nested @func_0() {
-    %0 = wasm.local i32
+    %0 = wasm.local of type i32
     wasm.loop : {
-      %1 = wasm.local_get %0 : memref<i32>
+      %1 = wasm.local_get %0 : ref to i32
       %2 = wasm.const 10 : i32
       %3 = wasm.lt_si %1 %2 : i32 -> i32
       wasm.branch_if %3 to level 0 else ^bb1
@@ -118,16 +118,16 @@ module {
 
 module {
   wasm.func nested @func_0() {
-    %0 = wasm.local i32
-    %1 = wasm.local i32
+    %0 = wasm.local of type i32
+    %1 = wasm.local of type i32
     wasm.loop : {
-      %2 = wasm.local_get %0 : memref<i32>
+      %2 = wasm.local_get %0 : ref to i32
       %3 = wasm.const 1 : i32
       %4 = wasm.add %2 %3 : i32
-      wasm.local_set %0 : memref<i32> to %4 : i32
+      wasm.local_set %0 : ref to i32 to %4 : i32
       wasm.loop : {
         %8 = wasm.const 12 : i32
-        %9 = wasm.local_get %0 : memref<i32>
+        %9 = wasm.local_get %0 : ref to i32
         %10 = wasm.gt_si %8 %9 : i32 -> i32
         wasm.branch_if %10 to level 0 else ^bb1
       ^bb1:  // pred: ^bb0

--- a/mlir/test/Conversion/RaiseWasm/wasm-max-to-arith-maximumf.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-max-to-arith-maximumf.mlir
@@ -1,21 +1,37 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @max_f32(
-// CHECK-SAME:      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:      %[[VAL_1:.*]]: f32) -> f32 {
-// CHECK:           %[[VAL_2:.*]] = arith.maximumf %[[VAL_0]], %[[VAL_1]] : f32
-// CHECK:           return %[[VAL_2]] : f32
-wasm.func nested @max_f32(%arg0: f32, %arg1: f32) -> f32 {
-    %op = wasm.max %arg0 %arg1 : f32
+// CHECK-SAME:      %[[ARG0:.*]]: f32,
+// CHECK-SAME:      %[[ARG1:.*]]: f32) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_4:.*]] = arith.maximumf %[[VAL_2]], %[[VAL_3]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+wasm.func nested @max_f32(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+    %v0 = wasm.local_get %arg0 : ref to f32
+    %v1 = wasm.local_get %arg1 : ref to f32
+    %op = wasm.max %v0 %v1 : f32
     wasm.return %op : f32
 }
 
 // CHECK-LABEL:   func.func @max_f64(
-// CHECK-SAME:      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:      %[[VAL_1:.*]]: f64) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = arith.maximumf %[[VAL_0]], %[[VAL_1]] : f64
-// CHECK:           return %[[VAL_2]] : f64
-wasm.func nested @max_f64(%arg0: f64, %arg1: f64) -> f64 {
-    %op = wasm.max %arg0 %arg1 : f64
+// CHECK-SAME:      %[[ARG0:.*]]: f64,
+// CHECK-SAME:      %[[ARG1:.*]]: f64) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_4:.*]] = arith.maximumf %[[VAL_2]], %[[VAL_3]] : f64
+// CHECK:           return %[[VAL_4]] : f64
+wasm.func nested @max_f64(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+    %v0 = wasm.local_get %arg0 : ref to f64
+    %v1 = wasm.local_get %arg1 : ref to f64
+    %op = wasm.max %v0 %v1 : f64
     wasm.return %op : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-min-to-arith-minimumf.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-min-to-arith-minimumf.mlir
@@ -1,21 +1,37 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @min_f32(
-// CHECK-SAME:      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:      %[[VAL_1:.*]]: f32) -> f32 {
-// CHECK:           %[[VAL_2:.*]] = arith.minimumf %[[VAL_0]], %[[VAL_1]] : f32
-// CHECK:           return %[[VAL_2]] : f32
-wasm.func nested @min_f32(%arg0: f32, %arg1: f32) -> f32 {
-    %op = wasm.min %arg0 %arg1 : f32
+// CHECK-SAME:      %[[ARG0:.*]]: f32,
+// CHECK-SAME:      %[[ARG1:.*]]: f32) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_4:.*]] = arith.minimumf %[[VAL_2]], %[[VAL_3]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+wasm.func nested @min_f32(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+    %v0 = wasm.local_get %arg0 : ref to f32
+    %v1 = wasm.local_get %arg1 : ref to f32
+    %op = wasm.min %v0 %v1 : f32
     wasm.return %op : f32
 }
 
 // CHECK-LABEL:   func.func @min_f64(
-// CHECK-SAME:      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:      %[[VAL_1:.*]]: f64) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = arith.minimumf %[[VAL_0]], %[[VAL_1]] : f64
-// CHECK:           return %[[VAL_2]] : f64
-wasm.func nested @min_f64(%arg0: f64, %arg1: f64) -> f64 {
-    %op = wasm.min %arg0 %arg1 : f64
+// CHECK-SAME:      %[[ARG0:.*]]: f64,
+// CHECK-SAME:      %[[ARG1:.*]]: f64) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_4:.*]] = arith.minimumf %[[VAL_2]], %[[VAL_3]] : f64
+// CHECK:           return %[[VAL_4]] : f64
+wasm.func nested @min_f64(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+    %v0 = wasm.local_get %arg0 : ref to f64
+    %v1 = wasm.local_get %arg1 : ref to f64
+    %op = wasm.min %v0 %v1 : f64
     wasm.return %op : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-mul-to-arith-mul.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-mul-to-arith-mul.mlir
@@ -1,47 +1,78 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir | FileCheck %s
 
-// CHECK-LABEL:   func.func @func_1(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i32) -> i32 {
-wasm.func nested @func_1(%arg0: i32, %arg1: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : i32
-%0 = wasm.mul %arg0 %arg1 : i32
-// CHECK:           return %[[VAL_2]] : i32
+// CHECK-LABEL:   func.func @mul_i32(
+// CHECK-SAME:                      %[[ARG0:.*]]: i32,
+// CHECK-SAME:                      %[[ARG1:.*]]: i32) -> i32 {
+wasm.func nested @mul_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+%v1 = wasm.local_get %arg1 : ref to i32
+// CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_2]], %[[VAL_3]] : i32
+%0 = wasm.mul %v0 %v1 : i32
+// CHECK:           return %[[VAL_4]] : i32
 wasm.return %0 : i32
 }
 
 // -----
 
-// CHECK-LABEL:   func.func @func_2(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i64) -> i64 {
-wasm.func nested @func_2(%arg0: i64, %arg1: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : i64
-%0 = wasm.mul %arg0 %arg1 : i64
-// CHECK:           return %[[VAL_2]] : i64
+// CHECK-LABEL:   func.func @mul_i64(
+// CHECK-SAME:                      %[[ARG0:.*]]: i64,
+// CHECK-SAME:                      %[[ARG1:.*]]: i64) -> i64 {
+wasm.func nested @mul_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+%v0 = wasm.local_get %arg0 : ref to i64
+%v1 = wasm.local_get %arg1 : ref to i64
+// CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_2]], %[[VAL_3]] : i64
+%0 = wasm.mul %v0 %v1 : i64
+// CHECK:           return %[[VAL_4]] : i64
 wasm.return %0 : i64
 }
-
 // -----
 
-// CHECK-LABEL:   func.func @func_3(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f32) -> f32 {
-wasm.func nested @func_3(%arg0: f32, %arg1: f32) -> f32 {
-// CHECK:           %[[VAL_2:.*]] = arith.mulf %[[VAL_0]], %[[VAL_1]] : f32
-%0 = wasm.mul %arg0 %arg1 : f32
-// CHECK:           return %[[VAL_2]] : f32
+// CHECK-LABEL:   func.func @mul_f32(
+// CHECK-SAME:                      %[[ARG0:.*]]: f32,
+// CHECK-SAME:                      %[[ARG1:.*]]: f32) -> f32 {
+wasm.func nested @mul_f32(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+%v0 = wasm.local_get %arg0 : ref to f32
+%v1 = wasm.local_get %arg1 : ref to f32
+// CHECK:           %[[VAL_4:.*]] = arith.mulf %[[VAL_2]], %[[VAL_3]] : f32
+%0 = wasm.mul %v0 %v1 : f32
+// CHECK:           return %[[VAL_4]] : f32
 wasm.return %0 : f32
 }
 
 // -----
 
-// CHECK-LABEL:   func.func @func_4(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f64) -> f64 {
-wasm.func nested @func_4(%arg0: f64, %arg1: f64) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = arith.mulf %[[VAL_0]], %[[VAL_1]] : f64
-%0 = wasm.mul %arg0 %arg1 : f64
-// CHECK:           return %[[VAL_2]] : f64
+// CHECK-LABEL:   func.func @mul_f64(
+// CHECK-SAME:                      %[[ARG0:.*]]: f64,
+// CHECK-SAME:                      %[[ARG1:.*]]: f64) -> f64 {
+wasm.func nested @mul_f64(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+%v0 = wasm.local_get %arg0 : ref to f64
+%v1 = wasm.local_get %arg1 : ref to f64
+// CHECK:           %[[VAL_4:.*]] = arith.mulf %[[VAL_2]], %[[VAL_3]] : f64
+%0 = wasm.mul %v0 %v1 : f64
+// CHECK:           return %[[VAL_4]] : f64
 wasm.return %0 : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-neg-to-arith-neg.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-neg-to-arith-neg.mlir
@@ -1,21 +1,27 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @neg_f32(
-// CHECK-SAME:      %[[VAL_0:.*]]: f32) -> f32 {
-// CHECK:           %[[VAL_1:.*]] = arith.negf %[[VAL_0]] : f32
-// CHECK:           return %[[VAL_1]] : f32
-// CHECK:         }
-wasm.func nested @neg_f32(%arg0: f32) -> f32 {
-    %op = wasm.neg %arg0 : f32
+// CHECK-SAME:      %[[ARG0:.*]]: f32) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = arith.negf %[[VAL_1]] : f32
+// CHECK:           return %[[VAL_2]] : f32
+wasm.func nested @neg_f32(%arg0: !wasm<local ref to f32>) -> f32 {
+    %val = wasm.local_get %arg0 : ref to f32
+    %op = wasm.neg %val : f32
     wasm.return %op : f32
 }
 
 // CHECK-LABEL:   func.func @neg_f64(
-// CHECK-SAME:      %[[VAL_0:.*]]: f64) -> f64 {
-// CHECK:           %[[VAL_1:.*]] = arith.negf %[[VAL_0]] : f64
-// CHECK:           return %[[VAL_1]] : f64
-// CHECK:         }
-wasm.func nested @neg_f64(%arg0: f64) -> f64 {
-    %op = wasm.neg %arg0 : f64
+// CHECK-SAME:      %[[ARG0:.*]]: f64) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = arith.negf %[[VAL_1]] : f64
+// CHECK:           return %[[VAL_2]] : f64
+wasm.func nested @neg_f64(%arg0: !wasm<local ref to f64>) -> f64 {
+    %val = wasm.local_get %arg0 : ref to f64
+    %op = wasm.neg %val : f64
     wasm.return %op : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-or-to-arith-or.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-or-to-arith-or.mlir
@@ -2,21 +2,37 @@
 
 
 // CHECK-LABEL:   func.func @or_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @or_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.or %arg0 %arg1 : i32
-    wasm.return %op : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32,
+// CHECK-SAME:                      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.ori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @or_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    %or = wasm.or %v0 %v1 : i32
+    wasm.return %or : i32
 }
 
 // CHECK-LABEL:   func.func @or_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @or_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.or %arg0 %arg1 : i64
-    wasm.return %op : i64
+// CHECK-SAME:                      %[[ARG0:.*]]: i64,
+// CHECK-SAME:                      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.ori %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @or_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    %or = wasm.or %v0 %v1 : i64
+    wasm.return %or : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-popcnt-to-math-ctpop.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-popcnt-to-math-ctpop.mlir
@@ -1,19 +1,27 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @popcnt_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = math.ctpop %[[VAL_0]] : i32
-// CHECK:           return %[[VAL_1]] : i32
-wasm.func nested @popcnt_i32(%arg0: i32) -> i32 {
-    %op = wasm.popcnt %arg0 : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = math.ctpop %[[VAL_1]] : i32
+// CHECK:           return %[[VAL_2]] : i32
+wasm.func nested @popcnt_i32(%arg0: !wasm<local ref to i32>) -> i32 {
+    %v = wasm.local_get %arg0 : ref to i32
+    %op = wasm.popcnt %v : i32
     wasm.return %op : i32
 }
 
 // CHECK-LABEL:   func.func @popcnt_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_1:.*]] = math.ctpop %[[VAL_0]] : i64
-// CHECK:           return %[[VAL_1]] : i64
-wasm.func nested @popcnt_i64(%arg0: i64) -> i64 {
-    %op = wasm.popcnt %arg0 : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = math.ctpop %[[VAL_1]] : i64
+// CHECK:           return %[[VAL_2]] : i64
+wasm.func nested @popcnt_i64(%arg0: !wasm<local ref to i64>) -> i64 {
+    %v = wasm.local_get %arg0 : ref to i64
+    %op = wasm.popcnt %v : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-rem-to-arith-rem.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-rem-to-arith-rem.mlir
@@ -2,41 +2,73 @@
 
 
 // CHECK-LABEL:   func.func @rem_ui_32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @rem_ui_32(%arg0: i32, %arg1: i32) -> i32 {
-    %rem = wasm.rem_ui %arg0 %arg1 : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.remui %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @rem_ui_32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0: ref to i32
+    %v1 = wasm.local_get %arg1: ref to i32
+    %rem = wasm.rem_ui %v0 %v1 : i32
     wasm.return %rem : i32
 }
 
 // CHECK-LABEL:   func.func @rem_si_32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @rem_si_32(%arg0: i32, %arg1: i32) -> i32 {
-    %rem = wasm.rem_si %arg0 %arg1 : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @rem_si_32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0: ref to i32
+    %v1 = wasm.local_get %arg1: ref to i32
+    %rem = wasm.rem_si %v0 %v1 : i32
     wasm.return %rem : i32
 }
 
 // CHECK-LABEL:   func.func @rem_ui_64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @rem_ui_64(%arg0: i64, %arg1: i64) -> i64 {
-    %rem = wasm.rem_ui %arg0 %arg1 : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.remui %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @rem_ui_64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0: ref to i64
+    %v1 = wasm.local_get %arg1: ref to i64
+    %rem = wasm.rem_ui %v0 %v1 : i64
     wasm.return %rem : i64
 }
 
 // CHECK-LABEL:   func.func @rem_si_64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @rem_si_64(%arg0: i64, %arg1: i64) -> i64 {
-    %rem = wasm.rem_si %arg0 %arg1 : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @rem_si_64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0: ref to i64
+    %v1 = wasm.local_get %arg1: ref to i64
+    %rem = wasm.rem_si %v0 %v1 : i64
     wasm.return %rem : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-rotl-to-arith.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-rotl-to-arith.mlir
@@ -7,8 +7,16 @@
 // res = (val >> (bits & 31)) | (val << (-bits & 31))
 
 // CHECK-LABEL:   func.func @rotl_i32(
-// CHECK-SAME:      %[[VAL:.*]]: i32,
-// CHECK-SAME:      %[[BITS:.*]]: i32) -> i32 {
+// CHECK-SAME:      %[[VALREF:.*]]: i32,
+// CHECK-SAME:      %[[BITSREF:.*]]: i32) -> i32 {
+
+// Storage etc
+// CHECK-DAG:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK-DAG:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK-DAG:           memref.store %[[VALREF]], %[[VAL_0]][] : memref<i32>
+// CHECK-DAG:           memref.store %[[BITSREF]], %[[VAL_1]][] : memref<i32>
+// CHECK-DAG:           %[[VAL:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK-DAG:           %[[BITS:.*]] = memref.load %[[VAL_1]][] : memref<i32>
 
 // (val << (bits & 31))
 // CHECK:           %[[THIRTY_ONE:.*]] = arith.constant 31 : i32
@@ -23,15 +31,26 @@
 
 // CHECK:           %[[RES:.*]] = arith.ori %[[SHRU]], %[[SHL]] : i32
 // CHECK:           return %[[RES]] : i32
-wasm.func nested @rotl_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.rotl %arg0 by %arg1 bits : i32
+wasm.func nested @rotl_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    
+    %op = wasm.rotl %v0 by %v1 bits : i32
     wasm.return %op : i32
 }
 
 // Same as above, but with 64 bits.
 // CHECK-LABEL:   func.func @rotl_i64(
-// CHECK-SAME:      %[[VAL:.*]]: i64,
-// CHECK-SAME:      %[[BITS:.*]]: i64) -> i64 {
+// CHECK-SAME:      %[[VALREF:.*]]: i64,
+// CHECK-SAME:      %[[BITSREF:.*]]: i64) -> i64 {
+
+// Storage etc
+// CHECK-DAG:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK-DAG:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK-DAG:           memref.store %[[VALREF]], %[[VAL_0]][] : memref<i64>
+// CHECK-DAG:           memref.store %[[BITSREF]], %[[VAL_1]][] : memref<i64>
+// CHECK-DAG:           %[[VAL:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK-DAG:           %[[BITS:.*]] = memref.load %[[VAL_1]][] : memref<i64>
 
 // (val << (bits & 63))
 // CHECK:           %[[SIXTY_THREE:.*]] = arith.constant 63 : i64
@@ -47,7 +66,10 @@ wasm.func nested @rotl_i32(%arg0: i32, %arg1: i32) -> i32 {
 // Form final result.
 // CHECK:           %[[RES:.*]] = arith.ori %[[SHRU]], %[[SHL]] : i64
 // CHECK:           return %[[RES]] : i64
-wasm.func nested @rotl_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.rotl %arg0 by %arg1 bits : i64
+wasm.func nested @rotl_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    
+    %op = wasm.rotl %v0 by %v1 bits : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-rotr-to-arith.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-rotr-to-arith.mlir
@@ -7,8 +7,16 @@
 // res = (val >> (bits & 31)) | (val << (-bits & 31))
 
 // CHECK-LABEL:   func.func @rotr_i32(
-// CHECK-SAME:      %[[VAL:.*]]: i32,
-// CHECK-SAME:      %[[BITS:.*]]: i32) -> i32 {
+// CHECK-SAME:      %[[VALREF:.*]]: i32,
+// CHECK-SAME:      %[[BITSREF:.*]]: i32) -> i32 {
+
+// Storage etc
+// CHECK-DAG:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK-DAG:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK-DAG:           memref.store %[[VALREF]], %[[VAL_0]][] : memref<i32>
+// CHECK-DAG:           memref.store %[[BITSREF]], %[[VAL_1]][] : memref<i32>
+// CHECK-DAG:           %[[VAL:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK-DAG:           %[[BITS:.*]] = memref.load %[[VAL_1]][] : memref<i32>
 
 // (val >> (bits & 31))
 // CHECK:           %[[THIRTY_ONE:.*]] = arith.constant 31 : i32
@@ -24,15 +32,26 @@
 // CHECK:           %[[RES:.*]] = arith.ori %[[SHRU]], %[[SHL]] : i32
 // CHECK:           return %[[RES]] : i32
 // CHECK:         }
-wasm.func nested @rotr_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.rotr %arg0 by %arg1 bits : i32
+wasm.func nested @rotr_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+        
+    %op = wasm.rotr %v0 by %v1 bits : i32
     wasm.return %op : i32
 }
 
 // Same as above, but with 64 bits.
 // CHECK-LABEL:   func.func @rotr_i64(
-// CHECK-SAME:      %[[VAL:.*]]: i64,
-// CHECK-SAME:      %[[BITS:.*]]: i64) -> i64 {
+// CHECK-SAME:      %[[VALREF:.*]]: i64,
+// CHECK-SAME:      %[[BITSREF:.*]]: i64) -> i64 {
+
+// Storage etc
+// CHECK-DAG:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK-DAG:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK-DAG:           memref.store %[[VALREF]], %[[VAL_0]][] : memref<i64>
+// CHECK-DAG:           memref.store %[[BITSREF]], %[[VAL_1]][] : memref<i64>
+// CHECK-DAG:           %[[VAL:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK-DAG:           %[[BITS:.*]] = memref.load %[[VAL_1]][] : memref<i64>
 
 // (val >> (bits & 63))
 // CHECK:           %[[SIXTY_THREE:.*]] = arith.constant 63 : i64
@@ -49,7 +68,10 @@ wasm.func nested @rotr_i32(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK:           %[[RES:.*]] = arith.ori %[[SHRU]], %[[SHL]] : i64
 // CHECK:           return %[[RES]] : i64
 // CHECK:         }
-wasm.func nested @rotr_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.rotr %arg0 by %arg1 bits : i64
+wasm.func nested @rotr_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+
+    %op = wasm.rotr %v0 by %v1 bits : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-shl-to-arith-shl.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-shl-to-arith-shl.mlir
@@ -2,21 +2,37 @@
 
 
 // CHECK-LABEL:   func.func @shl_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @shl_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.shl %arg0 by %arg1 bits : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @shl_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    %op = wasm.shl %v0 by %v1 bits : i32
     wasm.return %op : i32
 }
 
 // CHECK-LABEL:   func.func @shl_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @shl_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.shl %arg0 by %arg1 bits : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @shl_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    %op = wasm.shl %v0 by %v1 bits : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-shr_s-to-arith-shrs.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-shr_s-to-arith-shrs.mlir
@@ -1,21 +1,38 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
+
 // CHECK-LABEL:   func.func @shr_s_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @shr_s_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.shr_s %arg0 by %arg1 bits : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @shr_s_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    %op = wasm.shr_s %v0 by %v1 bits : i32
     wasm.return %op : i32
 }
 
 // CHECK-LABEL:   func.func @shr_s_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @shr_s_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.shr_s %arg0 by %arg1 bits : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @shr_s_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    %op = wasm.shr_s %v0 by %v1 bits : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-shr_u-to-arith-shru.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-shr_u-to-arith-shru.mlir
@@ -1,21 +1,37 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
 // CHECK-LABEL:   func.func @shr_u_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @shr_u_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.shr_u %arg0 by %arg1 bits : i32
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.shrui %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @shr_u_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    %op = wasm.shr_u %v0 by %v1 bits : i32
     wasm.return %op : i32
 }
 
 // CHECK-LABEL:   func.func @shr_u_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @shr_u_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.shr_u %arg0 by %arg1 bits : i64
+// CHECK-SAME:      %[[ARG0:.*]]: i64,
+// CHECK-SAME:      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.shrui %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @shr_u_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    %op = wasm.shr_u %v0 by %v1 bits : i64
     wasm.return %op : i64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-sub-to-arith-sub.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-sub-to-arith-sub.mlir
@@ -1,47 +1,80 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir | FileCheck %s
 
 // CHECK-LABEL:   func.func @func_1(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i32) -> i32 {
-wasm.func nested @func_1(%arg0: i32, %arg1: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : i32
-%0 = wasm.sub %arg0 %arg1 : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.return %0 : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32,
+// CHECK-SAME:                      %[[ARG1:.*]]: i32) -> i32 {
+wasm.func nested @func_1(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+%v0 = wasm.local_get %arg0 : ref to i32
+%v1 = wasm.local_get %arg1 : ref to i32
+// CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : i32
+%res = wasm.sub %v0 %v1 : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.return %res : i32
 }
 
 // -----
 
 // CHECK-LABEL:   func.func @func_2(
-// CHECK-SAME:                      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: i64) -> i64 {
-wasm.func nested @func_2(%arg0: i64, %arg1: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : i64
-%0 = wasm.sub %arg0 %arg1 : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.return %0 : i64
+// CHECK-SAME:                      %[[ARG0:.*]]: i64,
+// CHECK-SAME:                      %[[ARG1:.*]]: i64) -> i64 {
+wasm.func nested @func_2(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+%v0 = wasm.local_get %arg0 : ref to i64
+%v1 = wasm.local_get %arg1 : ref to i64
+// CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : i64
+%res = wasm.sub %v0 %v1 : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.return %res : i64
 }
 
 // -----
 
 // CHECK-LABEL:   func.func @func_3(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f32,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f32) -> f32 {
-wasm.func nested @func_3(%arg0: f32, %arg1: f32) -> f32 {
-// CHECK:           %[[VAL_2:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : f32
-%0 = wasm.sub %arg0 %arg1 : f32
-// CHECK:           return %[[VAL_2]] : f32
-wasm.return %0 : f32
+// CHECK-SAME:                      %[[ARG0:.*]]: f32,
+// CHECK-SAME:                      %[[ARG1:.*]]: f32) -> f32 {
+wasm.func nested @func_3(%arg0: !wasm<local ref to f32>, %arg1: !wasm<local ref to f32>) -> f32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f32>
+%v0 = wasm.local_get %arg0 : ref to f32
+%v1 = wasm.local_get %arg1 : ref to f32
+// CHECK:           %[[VAL_4:.*]] = arith.subf %[[VAL_2]], %[[VAL_3]] : f32
+%res = wasm.sub %v0 %v1 : f32
+// CHECK:           return %[[VAL_4]] : f32
+wasm.return %res : f32
 }
+
 
 // -----
 
 // CHECK-LABEL:   func.func @func_4(
-// CHECK-SAME:                      %[[VAL_0:.*]]: f64,
-// CHECK-SAME:                      %[[VAL_1:.*]]: f64) -> f64 {
-wasm.func nested @func_4(%arg0: f64, %arg1: f64) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : f64
-%0 = wasm.sub %arg0 %arg1 : f64
-// CHECK:           return %[[VAL_2]] : f64
-wasm.return %0 : f64
+// CHECK-SAME:                      %[[ARG0:.*]]: f64,
+// CHECK-SAME:                      %[[ARG1:.*]]: f64) -> f64 {
+wasm.func nested @func_4(%arg0: !wasm<local ref to f64>, %arg1: !wasm<local ref to f64>) -> f64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<f64>
+%v0 = wasm.local_get %arg0 : ref to f64
+%v1 = wasm.local_get %arg1 : ref to f64
+// CHECK:           %[[VAL_4:.*]] = arith.subf %[[VAL_2]], %[[VAL_3]] : f64
+%res = wasm.sub %v0 %v1 : f64
+// CHECK:           return %[[VAL_4]] : f64
+wasm.return %res : f64
 }

--- a/mlir/test/Conversion/RaiseWasm/wasm-xor-to-arith-xor.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-xor-to-arith-xor.mlir
@@ -1,22 +1,37 @@
 // RUN: mlir-opt --split-input-file %s --raise-wasm-mlir -o - | FileCheck %s
 
-
 // CHECK-LABEL:   func.func @xor_i32(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32,
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[VAL_2]] : i32
-wasm.func nested @xor_i32(%arg0: i32, %arg1: i32) -> i32 {
-    %op = wasm.xor %arg0 %arg1 : i32
-    wasm.return %op : i32
+// CHECK-SAME:                      %[[ARG0:.*]]: i32,
+// CHECK-SAME:                      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+wasm.func nested @xor_i32(%arg0: !wasm<local ref to i32>, %arg1: !wasm<local ref to i32>) -> i32 {
+    %v0 = wasm.local_get %arg0 : ref to i32
+    %v1 = wasm.local_get %arg1 : ref to i32
+    %xor = wasm.xor %v0 %v1 : i32
+    wasm.return %xor : i32
 }
 
 // CHECK-LABEL:   func.func @xor_i64(
-// CHECK-SAME:      %[[VAL_0:.*]]: i64,
-// CHECK-SAME:      %[[VAL_1:.*]]: i64) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK:           return %[[VAL_2]] : i64
-wasm.func nested @xor_i64(%arg0: i64, %arg1: i64) -> i64 {
-    %op = wasm.xor %arg0 %arg1 : i64
-    wasm.return %op : i64
+// CHECK-SAME:                      %[[ARG0:.*]]: i64,
+// CHECK-SAME:                      %[[ARG1:.*]]: i64) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG1]], %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i64>
+// CHECK:           memref.store %[[ARG0]], %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i64>
+// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_0]][] : memref<i64>
+// CHECK:           %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+wasm.func nested @xor_i64(%arg0: !wasm<local ref to i64>, %arg1: !wasm<local ref to i64>) -> i64 {
+    %v0 = wasm.local_get %arg0 : ref to i64
+    %v1 = wasm.local_get %arg1 : ref to i64
+    %xor = wasm.xor %v0 %v1 : i64
+    wasm.return %xor : i64
 }

--- a/mlir/test/Target/WebAssembly/add_div.mlir
+++ b/mlir/test/Target/WebAssembly/add_div.mlir
@@ -22,18 +22,16 @@
 // CHECK-LABEL:   wasm.import_func "twoTimes" from "env" as @func_0 {sym_visibility = "nested", type = (i32) -> i32}
 
 // CHECK-LABEL:   wasm.func @add(
-// CHECK-SAME:                   %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                   %[[VAL_1:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
-// CHECK:           %[[VAL_3:.*]] = wasm.local_from_arg %[[VAL_1]] : i32
-// CHECK:           %[[VAL_4:.*]] = wasm.local_get %[[VAL_2]] : memref<i32>
-// CHECK:           %[[VAL_5:.*]] = wasm.call @func_0(%[[VAL_4]]) : (i32) -> i32
-// CHECK:           %[[VAL_6:.*]] = wasm.local_get %[[VAL_3]] : memref<i32>
-// CHECK:           %[[VAL_7:.*]] = wasm.call @func_0(%[[VAL_6]]) : (i32) -> i32
-// CHECK:           %[[VAL_8:.*]] = wasm.add %[[VAL_5]] %[[VAL_7]] : i32
-// CHECK:           %[[VAL_9:.*]] = wasm.const 2 : i32
-// CHECK:           %[[VAL_10:.*]] = wasm.div_si %[[VAL_8]] %[[VAL_9]] : i32
-// CHECK:           wasm.return %[[VAL_10]] : i32
+// CHECK-SAME:                   %[[ARG0:.*]]: !wasm<local ref to i32>,
+// CHECK-SAME:                   %[[ARG1:.*]]: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:           %[[VAL_1:.*]] = wasm.call @func_0(%[[VAL_0]]) : (i32) -> i32
+// CHECK:           %[[VAL_2:.*]] = wasm.local_get %[[ARG1]] :  ref to i32
+// CHECK:           %[[VAL_3:.*]] = wasm.call @func_0(%[[VAL_2]]) : (i32) -> i32
+// CHECK:           %[[VAL_4:.*]] = wasm.add %[[VAL_1]] %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = wasm.const 2 : i32
+// CHECK:           %[[VAL_6:.*]] = wasm.div_si %[[VAL_4]] %[[VAL_5]] : i32
+// CHECK:           wasm.return %[[VAL_6]] : i32
 // CHECK:         }
 // CHECK:         "wasm.memory"() <{limits = !wasm<limit[2:]>, sym_name = "memory"}> : () -> ()
 

--- a/mlir/test/Target/WebAssembly/custom_parser/local.mlir
+++ b/mlir/test/Target/WebAssembly/custom_parser/local.mlir
@@ -2,47 +2,44 @@
 
 module {
   wasm.func nested @func_0() -> f32 {
-    %0 = wasm.local f32
-    %1 = wasm.local f32
+    %0 = wasm.local of type f32
+    %1 = wasm.local of type f32
     %2 = wasm.const 8.000000e+00 : f32
     %3 = wasm.const 1.200000e+01 : f32
     %4 = wasm.add %2 %3 : f32
     wasm.return %4 : f32
   }
   wasm.func nested @func_1() -> i32 {
-    %0 = wasm.local i32
-    %1 = wasm.local i32
+    %0 = wasm.local of type i32
+    %1 = wasm.local of type i32
     %2 = wasm.const 8 : i32
     %3 = wasm.const 12 : i32
     %4 = wasm.add %2 %3 : i32
     wasm.return %4 : i32
   }
-  wasm.func nested @func_2(%arg0: i32) -> i32 {
+  wasm.func nested @func_2(%arg0: !wasm<local ref to i32>) -> i32 {
     %0 = wasm.const 3 : i32
     wasm.return %0 : i32
   }
 }
 
 // CHECK-LABEL:   wasm.func nested @func_0() -> f32 {
-// CHECK:           %[[VAL_0:.*]] = wasm.local f32
-// CHECK:           %[[VAL_1:.*]] = wasm.local f32
+// CHECK:           %[[VAL_0:.*]] = wasm.local of type f32
+// CHECK:           %[[VAL_1:.*]] = wasm.local of type f32
 // CHECK:           %[[VAL_2:.*]] = wasm.const 8.000000e+00 : f32
 // CHECK:           %[[VAL_3:.*]] = wasm.const 1.200000e+01 : f32
 // CHECK:           %[[VAL_4:.*]] = wasm.add %[[VAL_2]] %[[VAL_3]] : f32
 // CHECK:           wasm.return %[[VAL_4]] : f32
-// CHECK:         }
 
 // CHECK-LABEL:   wasm.func nested @func_1() -> i32 {
-// CHECK:           %[[VAL_0:.*]] = wasm.local i32
-// CHECK:           %[[VAL_1:.*]] = wasm.local i32
+// CHECK:           %[[VAL_0:.*]] = wasm.local of type i32
+// CHECK:           %[[VAL_1:.*]] = wasm.local of type i32
 // CHECK:           %[[VAL_2:.*]] = wasm.const 8 : i32
 // CHECK:           %[[VAL_3:.*]] = wasm.const 12 : i32
 // CHECK:           %[[VAL_4:.*]] = wasm.add %[[VAL_2]] %[[VAL_3]] : i32
 // CHECK:           wasm.return %[[VAL_4]] : i32
-// CHECK:         }
 
 // CHECK-LABEL:   wasm.func nested @func_2(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = wasm.const 3 : i32
-// CHECK:           wasm.return %[[VAL_1]] : i32
-// CHECK:         }
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = wasm.const 3 : i32
+// CHECK:           wasm.return %[[VAL_0]] : i32

--- a/mlir/test/Target/WebAssembly/double_nested_loop.mlir
+++ b/mlir/test/Target/WebAssembly/double_nested_loop.mlir
@@ -33,20 +33,20 @@
 */
 
 // CHECK-LABEL:   wasm.func nested @func_0() {
-// CHECK:           %[[VAL_0:.*]] = wasm.local i32
-// CHECK:           %[[VAL_1:.*]] = wasm.local i32
+// CHECK:           %[[VAL_0:.*]] = wasm.local of type i32
+// CHECK:           %[[VAL_1:.*]] = wasm.local of type i32
 // CHECK:           wasm.loop : {
-// CHECK:             %[[VAL_2:.*]] = wasm.local_get %[[VAL_0]] : memref<i32>
+// CHECK:             %[[VAL_2:.*]] = wasm.local_get %[[VAL_0]] :  ref to i32
 // CHECK:             %[[VAL_3:.*]] = wasm.const 1 : i32
 // CHECK:             %[[VAL_4:.*]] = wasm.add %[[VAL_2]] %[[VAL_3]] : i32
-// CHECK:             wasm.local_set %[[VAL_0]] : memref<i32> to %[[VAL_4]] : i32
+// CHECK:             wasm.local_set %[[VAL_0]] :  ref to i32 to %[[VAL_4]] : i32
 // CHECK:             wasm.loop : {
 // CHECK:               %[[VAL_5:.*]] = wasm.const 1 : i32
-// CHECK:               %[[VAL_6:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
+// CHECK:               %[[VAL_6:.*]] = wasm.local_get %[[VAL_1]] :  ref to i32
 // CHECK:               %[[VAL_7:.*]] = wasm.const 12 : i32
 // CHECK:               %[[VAL_8:.*]] = wasm.add %[[VAL_6]] %[[VAL_7]] : i32
-// CHECK:               %[[VAL_9:.*]] = wasm.local_tee %[[VAL_1]] : memref<i32> to %[[VAL_8]] : i32
-// CHECK:               %[[VAL_10:.*]] = wasm.local_get %[[VAL_0]] : memref<i32>
+// CHECK:               %[[VAL_9:.*]] = wasm.local_tee %[[VAL_1]] :  ref to i32 to %[[VAL_8]] : i32
+// CHECK:               %[[VAL_10:.*]] = wasm.local_get %[[VAL_0]] :  ref to i32
 // CHECK:               %[[VAL_11:.*]] = wasm.gt_si %[[VAL_9]] %[[VAL_10]] : i32 -> i32
 // CHECK:               wasm.branch_if %[[VAL_11]] to level 0 else ^bb1
 // CHECK:             ^bb1:

--- a/mlir/test/Target/WebAssembly/empty_block_list_and_stack.mlir
+++ b/mlir/test/Target/WebAssembly/empty_block_list_and_stack.mlir
@@ -21,8 +21,7 @@
 */
 
 // CHECK-LABEL:   wasm.func nested @func_0(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-// CHECK:           %[[VAL_1:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) {
 // CHECK:           wasm.block : {
 // CHECK:             wasm.block : {
 // CHECK:               wasm.block : {
@@ -38,8 +37,7 @@
 // CHECK:           wasm.return
 
 // CHECK-LABEL:   wasm.func nested @func_1(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-// CHECK:           %[[VAL_1:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) {
 // CHECK:           wasm.block : {
 // CHECK:             wasm.block_return
 // CHECK:           }> ^bb1

--- a/mlir/test/Target/WebAssembly/if.mlir
+++ b/mlir/test/Target/WebAssembly/if.mlir
@@ -52,67 +52,67 @@
 */
 
 // CHECK-LABEL:   wasm.func nested @func_0(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
-// CHECK:           %[[VAL_2:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = wasm.const 1 : i32
-// CHECK:           %[[VAL_4:.*]] = wasm.and %[[VAL_2]] %[[VAL_3]] : i32
-// CHECK:           "wasm.if"(%[[VAL_4]])[^bb1] ({
-// CHECK:             %[[VAL_5:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:             %[[VAL_6:.*]] = wasm.const 3 : i32
-// CHECK:             %[[VAL_7:.*]] = wasm.mul %[[VAL_5]] %[[VAL_6]] : i32
-// CHECK:             %[[VAL_8:.*]] = wasm.const 1 : i32
-// CHECK:             %[[VAL_9:.*]] = wasm.add %[[VAL_7]] %[[VAL_8]] : i32
-// CHECK:             wasm.block_return %[[VAL_9]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:           %[[VAL_1:.*]] = wasm.const 1 : i32
+// CHECK:           %[[VAL_2:.*]] = wasm.and %[[VAL_0]] %[[VAL_1]] : i32
+// CHECK:           "wasm.if"(%[[VAL_2]])[^bb1] ({
+// CHECK:             %[[VAL_3:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:             %[[VAL_4:.*]] = wasm.const 3 : i32
+// CHECK:             %[[VAL_5:.*]] = wasm.mul %[[VAL_3]] %[[VAL_4]] : i32
+// CHECK:             %[[VAL_6:.*]] = wasm.const 1 : i32
+// CHECK:             %[[VAL_7:.*]] = wasm.add %[[VAL_5]] %[[VAL_6]] : i32
+// CHECK:             wasm.block_return %[[VAL_7]] : i32
 // CHECK:           }, {
-// CHECK:             %[[VAL_10:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:             %[[VAL_11:.*]] = wasm.const 1 : i32
-// CHECK:             %[[VAL_12:.*]] = wasm.shr_u %[[VAL_10]] by %[[VAL_11]] bits : i32
-// CHECK:             wasm.block_return %[[VAL_12]] : i32
+// CHECK:             %[[VAL_8:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:             %[[VAL_9:.*]] = wasm.const 1 : i32
+// CHECK:             %[[VAL_10:.*]] = wasm.shr_u %[[VAL_8]] by %[[VAL_9]] bits : i32
+// CHECK:             wasm.block_return %[[VAL_10]] : i32
 // CHECK:           }) : (i32) -> ()
-// CHECK:         ^bb1(%[[VAL_13:.*]]: i32):
-// CHECK:           wasm.return %[[VAL_13]] : i32
+// CHECK:         ^bb1(%[[VAL_11:.*]]: i32):
+// CHECK:           wasm.return %[[VAL_11]] : i32
+// CHECK:         }
 
 // CHECK-LABEL:   wasm.func nested @func_1(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
-// CHECK:           %[[VAL_2:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:           %[[VAL_4:.*]] = wasm.const 1 : i32
-// CHECK:           %[[VAL_5:.*]] = wasm.and %[[VAL_3]] %[[VAL_4]] : i32
-// CHECK:           "wasm.if"(%[[VAL_5]], %[[VAL_2]])[^bb1] ({
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = wasm.const 1 : i32
-// CHECK:             %[[VAL_8:.*]] = wasm.add %[[VAL_6]] %[[VAL_7]] : i32
-// CHECK:             wasm.block_return %[[VAL_8]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:           %[[VAL_1:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:           %[[VAL_2:.*]] = wasm.const 1 : i32
+// CHECK:           %[[VAL_3:.*]] = wasm.and %[[VAL_1]] %[[VAL_2]] : i32
+// CHECK:           "wasm.if"(%[[VAL_3]], %[[VAL_0]])[^bb1] ({
+// CHECK:           ^bb0(%[[VAL_4:.*]]: i32):
+// CHECK:             %[[VAL_5:.*]] = wasm.const 1 : i32
+// CHECK:             %[[VAL_6:.*]] = wasm.add %[[VAL_4]] %[[VAL_5]] : i32
+// CHECK:             wasm.block_return %[[VAL_6]] : i32
 // CHECK:           }, {
 // CHECK:           }) : (i32, i32) -> ()
-// CHECK:         ^bb1(%[[VAL_9:.*]]: i32):
-// CHECK:           wasm.return %[[VAL_9]] : i32
+// CHECK:         ^bb1(%[[VAL_7:.*]]: i32):
+// CHECK:           wasm.return %[[VAL_7]] : i32
+// CHECK:         }
 
 // CHECK-LABEL:   wasm.func nested @func_2(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
-// CHECK:           %[[VAL_2:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = wasm.ctz %[[VAL_2]] : i32
-// CHECK:           "wasm.if"(%[[VAL_3]])[^bb1] ({
-// CHECK:             %[[VAL_4:.*]] = wasm.const 2 : i32
-// CHECK:             %[[VAL_5:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:             %[[VAL_6:.*]] = wasm.const 1 : i32
-// CHECK:             %[[VAL_7:.*]] = wasm.shr_u %[[VAL_5]] by %[[VAL_6]] bits : i32
-// CHECK:             %[[VAL_8:.*]] = wasm.ctz %[[VAL_7]] : i32
-// CHECK:             "wasm.if"(%[[VAL_8]], %[[VAL_4]])[^bb1] ({
-// CHECK:             ^bb0(%[[VAL_9:.*]]: i32):
-// CHECK:               %[[VAL_10:.*]] = wasm.const 2 : i32
-// CHECK:               %[[VAL_11:.*]] = wasm.add %[[VAL_9]] %[[VAL_10]] : i32
-// CHECK:               wasm.block_return %[[VAL_11]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:           %[[VAL_1:.*]] = wasm.ctz %[[VAL_0]] : i32
+// CHECK:           "wasm.if"(%[[VAL_1]])[^bb1] ({
+// CHECK:             %[[VAL_2:.*]] = wasm.const 2 : i32
+// CHECK:             %[[VAL_3:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:             %[[VAL_4:.*]] = wasm.const 1 : i32
+// CHECK:             %[[VAL_5:.*]] = wasm.shr_u %[[VAL_3]] by %[[VAL_4]] bits : i32
+// CHECK:             %[[VAL_6:.*]] = wasm.ctz %[[VAL_5]] : i32
+// CHECK:             "wasm.if"(%[[VAL_6]], %[[VAL_2]])[^bb1] ({
+// CHECK:             ^bb0(%[[VAL_7:.*]]: i32):
+// CHECK:               %[[VAL_8:.*]] = wasm.const 2 : i32
+// CHECK:               %[[VAL_9:.*]] = wasm.add %[[VAL_7]] %[[VAL_8]] : i32
+// CHECK:               wasm.block_return %[[VAL_9]] : i32
 // CHECK:             }, {
 // CHECK:             }) : (i32, i32) -> ()
-// CHECK:           ^bb1(%[[VAL_12:.*]]: i32):
-// CHECK:             wasm.block_return %[[VAL_12]] : i32
+// CHECK:           ^bb1(%[[VAL_10:.*]]: i32):
+// CHECK:             wasm.block_return %[[VAL_10]] : i32
 // CHECK:           }, {
-// CHECK:             %[[VAL_13:.*]] = wasm.const 1 : i32
-// CHECK:             wasm.block_return %[[VAL_13]] : i32
+// CHECK:             %[[VAL_11:.*]] = wasm.const 1 : i32
+// CHECK:             wasm.block_return %[[VAL_11]] : i32
 // CHECK:           }) : (i32) -> ()
-// CHECK:         ^bb1(%[[VAL_14:.*]]: i32):
-// CHECK:           wasm.return %[[VAL_14]] : i32
+// CHECK:         ^bb1(%[[VAL_12:.*]]: i32):
+// CHECK:           wasm.return %[[VAL_12]] : i32
+// CHECK:         }

--- a/mlir/test/Target/WebAssembly/local.mlir
+++ b/mlir/test/Target/WebAssembly/local.mlir
@@ -30,31 +30,30 @@
 */
 
 // CHECK-LABEL:   wasm.func nested @func_0() -> f32 {
-// CHECK:           %[[VAL_0:.*]] = wasm.local f32
-// CHECK:           %[[VAL_1:.*]] = wasm.local f32
+// CHECK:           %[[VAL_0:.*]] = wasm.local of type f32
+// CHECK:           %[[VAL_1:.*]] = wasm.local of type f32
 // CHECK:           %[[VAL_2:.*]] = wasm.const 8.000000e+00 : f32
-// CHECK:           wasm.local_set %[[VAL_0]] : memref<f32> to %[[VAL_2]] : f32
-// CHECK:           %[[VAL_3:.*]] = wasm.local_get %[[VAL_0]] : memref<f32>
+// CHECK:           wasm.local_set %[[VAL_0]] :  ref to f32 to %[[VAL_2]] : f32
+// CHECK:           %[[VAL_3:.*]] = wasm.local_get %[[VAL_0]] :  ref to f32
 // CHECK:           %[[VAL_4:.*]] = wasm.const 1.200000e+01 : f32
-// CHECK:           %[[VAL_5:.*]] = wasm.local_tee %[[VAL_1]] : memref<f32> to %[[VAL_4]] : f32
+// CHECK:           %[[VAL_5:.*]] = wasm.local_tee %[[VAL_1]] :  ref to f32 to %[[VAL_4]] : f32
 // CHECK:           %[[VAL_6:.*]] = wasm.add %[[VAL_3]] %[[VAL_5]] : f32
 // CHECK:           wasm.return %[[VAL_6]] : f32
 
 // CHECK-LABEL:   wasm.func nested @func_1() -> i32 {
-// CHECK:           %[[VAL_0:.*]] = wasm.local i32
-// CHECK:           %[[VAL_1:.*]] = wasm.local i32
+// CHECK:           %[[VAL_0:.*]] = wasm.local of type i32
+// CHECK:           %[[VAL_1:.*]] = wasm.local of type i32
 // CHECK:           %[[VAL_2:.*]] = wasm.const 8 : i32
-// CHECK:           wasm.local_set %[[VAL_0]] : memref<i32> to %[[VAL_2]] : i32
-// CHECK:           %[[VAL_3:.*]] = wasm.local_get %[[VAL_0]] : memref<i32>
+// CHECK:           wasm.local_set %[[VAL_0]] :  ref to i32 to %[[VAL_2]] : i32
+// CHECK:           %[[VAL_3:.*]] = wasm.local_get %[[VAL_0]] :  ref to i32
 // CHECK:           %[[VAL_4:.*]] = wasm.const 12 : i32
-// CHECK:           %[[VAL_5:.*]] = wasm.local_tee %[[VAL_1]] : memref<i32> to %[[VAL_4]] : i32
+// CHECK:           %[[VAL_5:.*]] = wasm.local_tee %[[VAL_1]] :  ref to i32 to %[[VAL_4]] : i32
 // CHECK:           %[[VAL_6:.*]] = wasm.add %[[VAL_3]] %[[VAL_5]] : i32
 // CHECK:           wasm.return %[[VAL_6]] : i32
 
 // CHECK-LABEL:   wasm.func nested @func_2(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> i32 {
-// CHECK:           %[[VAL_1:.*]] = wasm.local_from_arg %[[VAL_0]] : i32
-// CHECK:           %[[VAL_2:.*]] = wasm.const 3 : i32
-// CHECK:           wasm.local_set %[[VAL_1]] : memref<i32> to %[[VAL_2]] : i32
-// CHECK:           %[[VAL_3:.*]] = wasm.local_get %[[VAL_1]] : memref<i32>
-// CHECK:           wasm.return %[[VAL_3]] : i32
+// CHECK-SAME:      %[[ARG0:.*]]: !wasm<local ref to i32>) -> i32 {
+// CHECK:           %[[VAL_0:.*]] = wasm.const 3 : i32
+// CHECK:           wasm.local_set %[[ARG0]] :  ref to i32 to %[[VAL_0]] : i32
+// CHECK:           %[[VAL_1:.*]] = wasm.local_get %[[ARG0]] :  ref to i32
+// CHECK:           wasm.return %[[VAL_1]] : i32

--- a/mlir/test/Target/WebAssembly/loop_with_inst.mlir
+++ b/mlir/test/Target/WebAssembly/loop_with_inst.mlir
@@ -18,13 +18,13 @@
 )*/
 
 // CHECK-LABEL:   wasm.func nested @func_0() -> i32 {
-// CHECK:           %[[VAL_0:.*]] = wasm.local i32
+// CHECK:           %[[VAL_0:.*]] = wasm.local of type i32
 // CHECK:           wasm.loop : {
-// CHECK:             %[[VAL_1:.*]] = wasm.local_get %[[VAL_0]] : memref<i32>
+// CHECK:             %[[VAL_1:.*]] = wasm.local_get %[[VAL_0]] :  ref to i32
 // CHECK:             %[[VAL_2:.*]] = wasm.const 1 : i32
 // CHECK:             %[[VAL_3:.*]] = wasm.add %[[VAL_1]] %[[VAL_2]] : i32
-// CHECK:             wasm.local_set %[[VAL_0]] : memref<i32> to %[[VAL_3]] : i32
-// CHECK:             %[[VAL_4:.*]] = wasm.local_get %[[VAL_0]] : memref<i32>
+// CHECK:             wasm.local_set %[[VAL_0]] :  ref to i32 to %[[VAL_3]] : i32
+// CHECK:             %[[VAL_4:.*]] = wasm.local_get %[[VAL_0]] :  ref to i32
 // CHECK:             %[[VAL_5:.*]] = wasm.const 10 : i32
 // CHECK:             %[[VAL_6:.*]] = wasm.lt_si %[[VAL_4]] %[[VAL_5]] : i32 -> i32
 // CHECK:             wasm.block_return %[[VAL_6]] : i32


### PR DESCRIPTION
Based on discussion on the RFC.
Function arguments behaves like local variables in Wasm (they can't be accessed directly, but need to be pushed on stack, set from stack using specific operations).

This commit:
 - introduces a custom reference type for arguments and local variable (was using memref before)
 - ensure the block arguments of `wasm.func` entry block have this type
 - get rid of the local_from_arg op which was required when arguments were passed by value and is no longer required.