### PR TITLE
[mlir][wasm] NFC: Add a test checking behaviour on bad Wasm version

### DIFF
--- a/mlir/test/Target/WebAssembly/bad_wasm_version.yaml
+++ b/mlir/test/Target/WebAssembly/bad_wasm_version.yaml
@@ -1,0 +1,8 @@
+# RUN: yaml2obj %s -o - | not mlir-translate --import-wasm 2>&1 | FileCheck %s
+
+# CHECK: Unsupported Wasm version
+
+--- !WASM
+FileHeader:
+  Version:         0xDEADBEEF
+...


### PR DESCRIPTION
Add a yaml2obj-based test with a bad WASM header. Verify the parser handles it.