### PR TITLE
[wasm][mlir] Add a yaml2obj test verifying behaviour on missing headers

### DIFF
--- a/mlir/test/Target/WebAssembly/missing_header.yaml
+++ b/mlir/test/Target/WebAssembly/missing_header.yaml
@@ -1,0 +1,12 @@
+# RUN: not yaml2obj %s -o - | not mlir-translate --import-wasm 2>&1 | FileCheck %s
+
+# CHECK: Source file does not contain valid Wasm header
+
+--- !WASM
+Sections:
+  - Type:            TYPE
+    Signatures:
+      - Index:           0
+        ParamTypes:      []
+        ReturnTypes:     []
+...


### PR DESCRIPTION
Verify that we emit an error when we get a wasm file without a Wasm header.