### PR TITLE
[wasm][mlir] Add test to verify out of scope function export error

### DIFF
--- a/mlir/test/Target/WebAssembly/function_export_out_of_scope.yaml
+++ b/mlir/test/Target/WebAssembly/function_export_out_of_scope.yaml
@@ -1,0 +1,15 @@
+# RUN: yaml2obj %s | mlir-translate --import-wasm -o - 2>&1 | FileCheck %s
+
+# FIXME: The error code here should be nonzero.
+
+# CHECK: Trying to export function 42 which is undefined in this scope
+
+--- !WASM
+FileHeader:
+  Version:         0x00000001
+Sections:
+  - Type:            EXPORT
+    Exports:
+      - Name:            function_export
+        Kind:            FUNCTION
+        Index:           42


### PR DESCRIPTION
Test via broken .wasm via yaml2obj.

Note that the error code is incorrect when we fail here. For now, let's just add the test and then fix it later.