### PR TITLE
[mlir][wasm] Add test for invalid function type index

### DIFF
--- a/mlir/test/Target/WebAssembly/invalid_function_type_index.yaml
+++ b/mlir/test/Target/WebAssembly/invalid_function_type_index.yaml
@@ -1,0 +1,18 @@
+# RUN: yaml2obj %s | mlir-translate --import-wasm -o - 2>&1 | FileCheck %s
+# CHECK: error: Invalid type index: 2
+
+# FIXME: mlir-translate should not return 0 here.
+
+--- !WASM
+FileHeader:
+  Version:         0x00000001
+Sections:
+  - Type:            TYPE
+    Signatures:
+      - Index:           0
+        ParamTypes:
+          - I32
+        ReturnTypes:     []
+  - Type:            FUNCTION
+    FunctionTypes:
+      - 2

--- a/wasabi/tools/WasmToIR.cpp
+++ b/wasabi/tools/WasmToIR.cpp
@@ -15,7 +15,11 @@
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMPass.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
+<<<<<<< HEAD
 #include "mlir/Conversion/RaiseWasm/RaiseWasmMLIR.h"
+=======
+#include "mlir/Conversion/WasmToStandard/WasmToStandard.h"
+>>>>>>> 5ea2a423fe94 ([mlir][wasm] Introduce wasabi binary driver for wasm to llvm ir translation)
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"

--- a/wasabi/tools/WasmToIR.cpp
+++ b/wasabi/tools/WasmToIR.cpp
@@ -15,11 +15,7 @@
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMPass.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
-<<<<<<< HEAD
 #include "mlir/Conversion/RaiseWasm/RaiseWasmMLIR.h"
-=======
-#include "mlir/Conversion/WasmToStandard/WasmToStandard.h"
->>>>>>> 5ea2a423fe94 ([mlir][wasm] Introduce wasabi binary driver for wasm to llvm ir translation)
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"


### PR DESCRIPTION
Verify that the parser will fail on a nonexistent type index.